### PR TITLE
Add direct control without specifying group names

### DIFF
--- a/protos/offboard/offboard.proto
+++ b/protos/offboard/offboard.proto
@@ -10,6 +10,7 @@ service OffboardService {
     rpc Stop(StopRequest) returns(StopResponse) {}
     rpc IsActive(IsActiveRequest) returns(IsActiveResponse) {}
     rpc SetAttitude(SetAttitudeRequest) returns(SetAttitudeResponse) {}
+    rpc SetActuatorControl(SetActuatorControlRequest) returns(SetActuatorControlResponse) {}
     rpc SetAttitudeRate(SetAttitudeRateRequest) returns(SetAttitudeRateResponse) {}
     rpc SetPositionNed(SetPositionNedRequest) returns(SetPositionNedResponse) {}
     rpc SetVelocityBody(SetVelocityBodyRequest) returns(SetVelocityBodyResponse) {}
@@ -36,6 +37,11 @@ message SetAttitudeRequest {
 }
 message SetAttitudeResponse {};
 
+message SetActuatorControlRequest {
+  ActuatorControl actuator_control = 1;
+}
+message SetActuatorControlResponse {};
+
 message SetAttitudeRateRequest {
     AttitudeRate attitude_rate = 1;
 }
@@ -61,6 +67,18 @@ message Attitude {
   float pitch_deg = 2;
   float yaw_deg = 3;
   float thrust_value = 4;
+}
+
+message ActuatorControl {
+  enum ActuatorGroup {
+    FLIGHT_CONTROL = 0;
+    FLIGHT_CONTROL_VTOL = 1;
+    GIMBAL = 2;
+    MANUAL_PASSTHROUGH = 3;
+  }
+
+  ActuatorGroup actuator_group = 1;
+  repeated float actuator_values = 2 [packed=true];
 }
 
 message AttitudeRate {

--- a/protos/offboard/offboard.proto
+++ b/protos/offboard/offboard.proto
@@ -70,8 +70,7 @@ message Attitude {
 }
 
 message ActuatorControl {
-  repeated float actuator_values = 1;
-  uint32 actuator_group = 2;
+  repeated float controls = 1;
 }
 
 message AttitudeRate {

--- a/protos/offboard/offboard.proto
+++ b/protos/offboard/offboard.proto
@@ -69,12 +69,12 @@ message Attitude {
   float thrust_value = 4;
 }
 
-message ControlGroup {
+message ActuatorControlGroup {
  repeated float controls = 1;
 }
 
 message ActuatorControl {
- repeated ControlGroup control_group = 1;
+ repeated ActuatorControlGroup groups = 1;
 }
 
 message AttitudeRate {

--- a/protos/offboard/offboard.proto
+++ b/protos/offboard/offboard.proto
@@ -78,7 +78,7 @@ message ActuatorControl {
   }
 
   ActuatorGroup actuator_group = 1;
-  repeated float actuator_values = 2 [packed=true];
+  repeated float actuator_values = 2;
 }
 
 message AttitudeRate {

--- a/protos/offboard/offboard.proto
+++ b/protos/offboard/offboard.proto
@@ -70,15 +70,8 @@ message Attitude {
 }
 
 message ActuatorControl {
-  enum ActuatorGroup {
-    FLIGHT_CONTROL = 0;
-    FLIGHT_CONTROL_VTOL = 1;
-    GIMBAL = 2;
-    MANUAL_PASSTHROUGH = 3;
-  }
-
-  ActuatorGroup actuator_group = 1;
-  repeated float actuator_values = 2;
+  repeated float actuator_values = 1;
+  uint32 actuator_group = 2;
 }
 
 message AttitudeRate {

--- a/protos/offboard/offboard.proto
+++ b/protos/offboard/offboard.proto
@@ -69,8 +69,12 @@ message Attitude {
   float thrust_value = 4;
 }
 
+message ControlGroup {
+ repeated float controls = 1;
+}
+
 message ActuatorControl {
-  repeated float controls = 1;
+ repeated ControlGroup control_group = 1;
 }
 
 message AttitudeRate {


### PR DESCRIPTION
This is a corresponding PR to one made in DronecodeSDK [here](https://github.com/mavlink/MAVSDK/pull/782)
Python primitive types translates: https://github.com/mavlink/MAVSDK-Python/pull/76