### PR TITLE
Rename java package to mavsdk io

### DIFF
--- a/pb_plugins/protoc_gen_dcsdk/type_info.py
+++ b/pb_plugins/protoc_gen_dcsdk/type_info.py
@@ -72,24 +72,6 @@ class TypeInfo:
             return self._default_types[type_id]
 
     @property
-    def parent_type(self):
-        """ Extracts parent type. This assumes that nesting is not deeper
-        than 1 level.
-
-        Note that it also assumes that the package name has 3 words. It
-        will start with a '.', giving something like:
-        '.io.mavlink.mavsdk.ActionResult.Result'."""
-        if self.is_primitive:
-            return None
-
-        type_tree = self._field.type_name.split(".")
-
-        if len(type_tree) <= 5:
-            return None
-
-        return str(type_tree[-2])
-
-    @property
     def is_result(self):
         """ Check if the field is a *Result """
         return self.name.endswith("Result")

--- a/pb_plugins/test/test_name_parser.py
+++ b/pb_plugins/test/test_name_parser.py
@@ -1,6 +1,6 @@
 import unittest
 
-from dcsdkgen.name_parser import (NameParser, NameParserFactory)
+from protoc_gen_dcsdk.name_parser import (NameParser, NameParserFactory)
 from unittest.mock import patch, mock_open
 
 class TestNameParser(unittest.TestCase):

--- a/pb_plugins/test/test_type_info.py
+++ b/pb_plugins/test/test_type_info.py
@@ -1,7 +1,7 @@
 import unittest
 
 from collections import namedtuple
-from dcsdkgen.type_info import (TypeInfo, TypeInfoFactory)
+from protoc_gen_dcsdk.type_info import (TypeInfo, TypeInfoFactory)
 from unittest.mock import patch, mock_open
 
 class TestTypeInfo(unittest.TestCase):

--- a/protos/action/action.proto
+++ b/protos/action/action.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package mavsdk.rpc.action;
 
-option java_package = "io.mavlink.mavsdk.action";
+option java_package = "io.mavsdk.action";
 option java_outer_classname = "ActionProto";
 
 service ActionService {

--- a/protos/calibration/calibration.proto
+++ b/protos/calibration/calibration.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package mavsdk.rpc.calibration;
 
-option java_package = "io.mavlink.mavsdk.calibration";
+option java_package = "io.mavsdk.calibration";
 option java_outer_classname = "CalibrationProto";
 
 service CalibrationService {

--- a/protos/camera/camera.proto
+++ b/protos/camera/camera.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package mavsdk.rpc.camera;
 
-option java_package = "io.mavlink.mavsdk.camera";
+option java_package = "io.mavsdk.camera";
 option java_outer_classname = "CameraProto";
 
 service CameraService {

--- a/protos/core/core.proto
+++ b/protos/core/core.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package mavsdk.rpc.core;
 
-option java_package = "io.mavlink.mavsdk.core";
+option java_package = "io.mavsdk.core";
 option java_outer_classname = "CoreProto";
 
 service CoreService {

--- a/protos/gimbal/gimbal.proto
+++ b/protos/gimbal/gimbal.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package mavsdk.rpc.gimbal;
 
-option java_package = "io.mavlink.mavsdk.gimbal";
+option java_package = "io.mavsdk.gimbal";
 option java_outer_classname = "GimbalProto";
 
 service GimbalService {

--- a/protos/info/info.proto
+++ b/protos/info/info.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package mavsdk.rpc.info;
 
-option java_package = "io.mavlink.mavsdk.info";
+option java_package = "io.mavsdk.info";
 option java_outer_classname = "InfoProto";
 
 service InfoService {

--- a/protos/mission/mission.proto
+++ b/protos/mission/mission.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package mavsdk.rpc.mission;
 
-option java_package = "io.mavlink.mavsdk.mission";
+option java_package = "io.mavsdk.mission";
 option java_outer_classname = "MissionProto";
 
 service MissionService {

--- a/protos/offboard/offboard.proto
+++ b/protos/offboard/offboard.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package mavsdk.rpc.offboard;
 
-option java_package = "io.mavlink.mavsdk.offboard";
+option java_package = "io.mavsdk.offboard";
 option java_outer_classname = "OffboardProto";
 
 service OffboardService {

--- a/protos/param/param.proto
+++ b/protos/param/param.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package mavsdk.rpc.param;
 
-option java_package = "io.mavlink.mavsdk.param";
+option java_package = "io.mavsdk.param";
 option java_outer_classname = "ParamProto";
 
 service ParamService {

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package mavsdk.rpc.telemetry;
 
-option java_package = "io.mavlink.mavsdk.telemetry";
+option java_package = "io.mavsdk.telemetry";
 option java_outer_classname = "TelemetryProto";
 
 service TelemetryService {


### PR DESCRIPTION
At the same time, remove an unused and somewhat confusing property (`parent_type`), and fix the tests.