### PR TITLE
add travis CI and prototool linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: minimal
+
+services:
+    - docker
+
+install:
+- set -e;
+- docker pull uber/prototool:1.8.1;
+
+script:
+- set -e;
+- docker run -v "$(pwd):/work" uber/prototool:1.8.1 prototool lint protos

--- a/prototool.yaml
+++ b/prototool.yaml
@@ -1,0 +1,11 @@
+protoc:
+  version: 3.6.1
+lint:
+  group: google
+  rules:
+    remove:
+      - ENUM_FIELD_PREFIXES
+      - ENUM_ZERO_VALUES_INVALID
+      - FILE_OPTIONS_REQUIRE_GO_PACKAGE
+      - FILE_OPTIONS_REQUIRE_JAVA_MULTIPLE_FILES
+      - FILE_OPTIONS_EQUAL_JAVA_PACKAGE_COM_PREFIX


### PR DESCRIPTION
Adding a linter in Travis.

This will check that the proto files are well formed. More can be done with prototool (e.g. formatting), but this is a start.