### PR TITLE
Parse documentation

### DIFF
--- a/pb_plugins/protoc_gen_dcsdk/autogen_file.py
+++ b/pb_plugins/protoc_gen_dcsdk/autogen_file.py
@@ -10,6 +10,7 @@ class File(object):
             plugin_name,
             package,
             template_env,
+            docs,
             enums,
             structs,
             methods,
@@ -17,6 +18,7 @@ class File(object):
         self._package = name_parser_factory.create(package)
         self._plugin_name = name_parser_factory.create(plugin_name)
         self._template = template_env.get_template("file.j2")
+        self._class_description = docs['class'].strip()
         self._enums = enums
         self._structs = structs
         self._methods = methods
@@ -25,6 +27,7 @@ class File(object):
     def __repr__(self):
         return self._template.render(package=self._package,
                                      plugin_name=self._plugin_name,
+                                     class_description=self._class_description,
                                      enums=self._enums.values(),
                                      structs=self._structs.values(),
                                      methods=self._methods.values(),

--- a/pb_plugins/protoc_gen_dcsdk/docs.py
+++ b/pb_plugins/protoc_gen_dcsdk/docs.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+
+class Docs():
+    """
+    Docs
+
+    Based on https://github.com/protocolbuffers/protobuf/blob/a08b03d4c00a5793b88b494f672513f6ad46a681/src/google/protobuf/descriptor.proto
+    """
+
+    @staticmethod
+    def collect_docs(source_code_info):
+
+        docs = {}
+
+        docs['methods'] = []
+        docs['structs'] = []
+        docs['enums'] = []
+
+        for location in source_code_info.location:
+            if len(location.path) > 0:
+                path = location.path
+
+                if path[0] == 1:  # name
+                    pass
+                elif path[0] == 2:  # package
+                    pass
+                elif path[0] == 4:  # message
+                    struct_id = path[1]
+
+                    if len(path) == 2:  # Top-level location of this message
+                        docs['structs'].append(
+                            {'description': location.leading_comments, 'params': []})
+                    # A field of this message
+                    elif len(path) == 4 and path[2] == 2:
+                        param_id = path[3]
+                        docs['structs'][struct_id]['params'].append(
+                            location.trailing_comments)
+                    elif path[2] == 3:  # A nested message
+                        nested_struct_id = path[3]
+
+                        if len(
+                                path) == 4:  # Top-level location of this nested message
+                            docs['structs'][struct_id]['structs'] = []
+                            docs['structs'][struct_id]['structs'].append(
+                                {'description': location.leading_comments, 'params': []})
+                        # A field of this nested message
+                        elif len(path) == 6 and path[4] == 2:
+                            docs['structs'][struct_id]['structs'][nested_struct_id]['params'].append(
+                                location.trailing_comments)
+                    elif path[2] == 4:  # A nested enum
+                        nested_enum_id = path[3]
+
+                        if len(path) == 4:  # Top-level location of this nested enum
+                            docs['structs'][struct_id]['enums'] = []
+                            docs['structs'][struct_id]['enums'].append(
+                                {'description': location.leading_comments, 'params': []})
+                        # A value of this nested message
+                        elif len(path) == 6 and path[4] == 2:
+                            docs['structs'][struct_id]['enums'][nested_enum_id]['params'].append(
+                                location.trailing_comments)
+
+                elif path[0] == 5:  # enum
+                    enum_id = path[1]
+
+                    if len(path) == 2:  # Top-level location of this enum
+                        docs['enums'].append(
+                            {'description': location.leading_comments, 'params': []})
+                    # A value of this message
+                    elif len(path) == 4 and path[2] == 2:
+                        param_id = path[3]
+                        docs['enums'][enum_id]['params'].append(
+                            location.trailing_comments)
+
+                elif path[0] == 6:  # service
+                    # The leading comment of the service is the description of
+                    # the class
+                    if len(path) == 2:
+                        if location.leading_comments:
+                            docs['class'] = location.leading_comments
+                        else:
+                            docs['class'] = ""
+
+                    # The service contains the methods (those are the 'rpc'
+                    # lines)
+                    if len(path) == 4:
+                        if location.leading_comments:
+                            docs['methods'].append(location.leading_comments)
+                        else:
+                            docs['methods'].append("")
+
+                elif path[0] == 8:  # option
+                    pass
+                elif path[0] == 12:  # syntax
+                    pass
+
+        return docs

--- a/pb_plugins/protoc_gen_dcsdk/enum.py
+++ b/pb_plugins/protoc_gen_dcsdk/enum.py
@@ -11,20 +11,27 @@ class Enum(object):
             package,
             template_env,
             pb_enum,
+            enum_docs,
             parent_struct=None):
         self._plugin_name = name_parser_factory.create(plugin_name)
         self._package = name_parser_factory.create(package)
         self._template = template_env.get_template("enum.j2")
+        self._enum_description = enum_docs['description'].strip(
+        ) if enum_docs else None
         self._name = name_parser_factory.create(pb_enum.name)
         self._values = []
         self._parent_struct = parent_struct
 
+        value_id = 0
         for value in pb_enum.value:
-            self._values.append(name_parser_factory.create(value.name))
+            self._values.append({'name': name_parser_factory.create(
+                value.name), 'description': enum_docs['params'][value_id]})
+            value_id += 1
 
     def __repr__(self):
         return self._template.render(plugin_name=self._plugin_name,
                                      package=self._package,
+                                     enum_description=self._enum_description,
                                      name=self._name,
                                      values=self._values,
                                      parent_struct=self._parent_struct)
@@ -35,11 +42,19 @@ class Enum(object):
             package,
             enums,
             template_env,
+            docs,
             parent_struct=None):
         _enums = {}
 
+        enum_id = 0
         for enum in enums:
-            _enums[enum.name] = Enum(
-                plugin_name, package, template_env, enum, parent_struct)
+            _enums[enum.name] = Enum(plugin_name,
+                                     package,
+                                     template_env,
+                                     enum,
+                                     docs['enums'][enum_id] if docs else None,
+                                     parent_struct)
+
+            enum_id += 1
 
         return _enums

--- a/pb_plugins/protoc_gen_dcsdk/struct.py
+++ b/pb_plugins/protoc_gen_dcsdk/struct.py
@@ -14,61 +14,82 @@ from jinja2.exceptions import TemplateNotFound
 class Struct(object):
     """ Struct """
 
-    def __init__(self, plugin_name, package, template_env, pb_struct):
+    def __init__(self, plugin_name, package,
+                 template_env, pb_struct, struct_docs):
         self._plugin_name = name_parser_factory.create(plugin_name)
         self._package = name_parser_factory.create(package)
         self._template = template_env.get_template("struct.j2")
+        self._struct_description = struct_docs['description'].strip(
+        ) if struct_docs else None
         self._name = name_parser_factory.create(pb_struct.name)
         self._fields = []
+
         self._nested_enums = Enum.collect_enums(
             plugin_name,
             package,
             pb_struct.enum_type,
             template_env,
+            struct_docs if 'enums' in struct_docs else None,
             parent_struct=self._name)
         self._nested_structs = Struct.collect_structs(
-            plugin_name, package, pb_struct.nested_type, template_env)
+            plugin_name, package, pb_struct.nested_type, template_env, struct_docs if 'structs' in struct_docs else None)
 
+        field_id = 0
         for field in pb_struct.field:
             self._fields.append(
                 Param(name_parser_factory.create(field.json_name),
-                      type_info_factory.create(field)))
+                      type_info_factory.create(field),
+                      struct_docs['params'][field_id]) if struct_docs else None)
+
+            field_id += 1
 
     def __repr__(self):
         return self._template.render(plugin_name=self._plugin_name,
                                      package=self._package,
+                                     struct_description=self._struct_description,
                                      name=self._name,
                                      fields=self._fields,
                                      nested_enums=self._nested_enums,
                                      nested_structs=self._nested_structs)
 
     @staticmethod
-    def collect_structs(plugin_name, package, structs, template_env):
+    def collect_structs(plugin_name, package, structs, template_env, docs):
         _structs = {}
 
+        struct_id = 0
         for struct in structs:
             if is_struct(struct):
                 _structs[struct.name] = Struct(
-                    plugin_name, package, template_env, struct)
+                    plugin_name, package, template_env, struct, docs['structs'][struct_id] if docs else None)
+
+            struct_id += 1
 
         return _structs
 
     @staticmethod
-    def collect_requests(package, structs):
+    def collect_requests(package, structs, docs):
         _requests = {}
 
+        struct_id = 0
         for struct in structs:
             if is_request(struct):
-                _requests[struct.name] = struct
+                _requests[struct.name] = {
+                    'struct': struct, 'docs': docs['structs'][struct_id]}
+
+            struct_id += 1
 
         return _requests
 
     @staticmethod
-    def collect_responses(package, structs):
+    def collect_responses(package, structs, docs):
         _responses = {}
 
+        struct_id = 0
         for struct in structs:
             if is_response(struct):
-                _responses[struct.name] = struct
+                _responses[struct.name] = {
+                    'struct': struct, 'docs': docs['structs'][struct_id]}
+
+            struct_id += 1
 
         return _responses

--- a/pb_plugins/protoc_gen_dcsdk/utils.py
+++ b/pb_plugins/protoc_gen_dcsdk/utils.py
@@ -9,15 +9,16 @@ type_info_factory = TypeInfoFactory()
 
 
 class Param:
-    def __init__(self, name, type_info):
+    def __init__(self, name, type_info, description):
         self.name = name
         self.type_info = type_info
+        self.description = description
 
 
 def no_return(method, responses):
     """ Checks if a method is completable """
     method_output = method.output_type.split(".")[-1]
-    method_response = responses[method_output]
+    method_response = responses[method_output]['struct']
 
     if (1 == len(method_response.field) and
             type_info_factory.create(method_response.field[0]).is_result):
@@ -51,15 +52,19 @@ def is_struct(struct):
             not struct.name.endswith("Response"))
 
 
-def filter_out_result(fields):
-    """ Filters out the result fields (".*Result$") """
+def filter_out_result(fields, fields_docs):
+    """ Filters out the result fields (".*Result$")  and
+    append the corresponding docs description """
+    field_id = 0
     for field in fields:
         if not field.type_name.endswith("Result"):
-            yield field
+            yield {'field': field, 'docs': fields_docs[field_id]}
+
+        field_id += 1
 
 
 def has_result(structs):
-    """ Checks if at least one struct is a *Result$. 
+    """ Checks if at least one struct is a *Result$.
         The expected input is a list of struct names. """
     for struct in structs:
         if struct.endswith("Result"):


### PR DESCRIPTION
This is adding the (admittedly) quite cryptic `docs.py` file, that tries to make sense of the comments in the proto files (based on documentation [here](https://github.com/protocolbuffers/protobuf/blob/a08b03d4c00a5793b88b494f672513f6ad46a681/src/google/protobuf/descriptor.proto)).

I believe this brings support for all the kind of documentation we currently need, including nested enums (one level only) and nested messages (which we currently don't use).

Resolves #91.