### PR TITLE
add documentation to proto files

### DIFF
--- a/protos/action/action.proto
+++ b/protos/action/action.proto
@@ -5,21 +5,97 @@ package mavsdk.rpc.action;
 option java_package = "io.mavsdk.action";
 option java_outer_classname = "ActionProto";
 
+// Enable simple actions such as arming, taking off, and landing.
 service ActionService {
+    /*
+     * Send command to arm the drone.
+     *
+     * Arming a drone normally causes motors to spin at idle.
+     * Before arming take all safety precautions and stand clear of the drone!
+     */
     rpc Arm(ArmRequest) returns(ArmResponse) {}
+    /*
+     * Send command to disarm the drone.
+     *
+     * This will disarm a drone that considers itself landed. If flying, the drone should
+     * reject the disarm command. Disarming means that all motors will stop.
+     */
     rpc Disarm(DisarmRequest) returns(DisarmResponse) {}
+    /*
+     * Send command to take off and hover.
+     *
+     * This switches the drone into position control mode and commands 
+     * it to take off and hover at the takeoff altitude.
+     *
+     * Note that the vehicle must be armed before it can take off.
+     */
     rpc Takeoff(TakeoffRequest) returns(TakeoffResponse) {}
+    /*
+     * Send command to land at the current position.
+     *
+     * This switches the drone to 'Land' flight mode.
+     */
     rpc Land(LandRequest) returns(LandResponse) {}
+    /*
+     * Send command to reboot the drone components.
+     *
+     * This will reboot the autopilot, companion computer, camera and gimbal.
+     */
     rpc Reboot(RebootRequest) returns(RebootResponse) {}
+    /*
+     * Send command to kill the drone. 
+     *
+     * This will disarm a drone irrespective of whether it is landed or flying.
+     * Note that the drone will fall out of the sky if this command is used while flying.
+     */
     rpc Kill(KillRequest) returns(KillResponse) {}
+    /*
+     * Send command to return to the launch (takeoff) position and land.
+     *
+     * This switches the drone into [RTL mode](https://docs.px4.io/en/flight_modes/rtl.html) which
+     * generally means it will rise up to a certain altitude to clear any obstacles before heading
+     * back to the launch (takeoff) position and land there.
+     */
     rpc ReturnToLaunch(ReturnToLaunchRequest) returns(ReturnToLaunchResponse) {}
+    /*
+     * Send command to transition the drone to fixedwing.
+     *
+     * The associated action will only be executed for VTOL vehicles (on other vehicle types the
+     * command will fail). The command will succeed if called when the vehicle
+     * is already in fixedwing mode.
+     */
     rpc TransitionToFixedWing(TransitionToFixedWingRequest) returns(TransitionToFixedWingResponse) {}
+    /*
+     * Send command to transition the drone to multicopter.
+     *
+     * The associated action will only be executed for VTOL vehicles (on other vehicle types the
+     * command will fail). The command will succeed if called when the vehicle
+     * is already in multicopter mode.
+     */
     rpc TransitionToMulticopter(TransitionToMulticopterRequest) returns(TransitionToMulticopterResponse) {}
+    /*
+     * Get the takeoff altitude (in meters above ground).
+     */
     rpc GetTakeoffAltitude(GetTakeoffAltitudeRequest) returns(GetTakeoffAltitudeResponse) {}
+    /*
+     * Set takeoff altitude (in meters above ground).
+     */
     rpc SetTakeoffAltitude(SetTakeoffAltitudeRequest) returns(SetTakeoffAltitudeResponse) {}
+    /*
+     * Get the vehicle maximum speed (in metres/second).
+     */
     rpc GetMaximumSpeed(GetMaximumSpeedRequest) returns(GetMaximumSpeedResponse) {}
+    /*
+     * Set vehicle maximum speed (in metres/second).
+     */
     rpc SetMaximumSpeed(SetMaximumSpeedRequest) returns(SetMaximumSpeedResponse) {}
+    /*
+     * Get the return to launch minimum return altitude (in meters).
+     */
     rpc GetReturnToLaunchAltitude(GetReturnToLaunchAltitudeRequest) returns(GetReturnToLaunchAltitudeResponse) {}
+    /*
+     * Set the return to launch minimum return altitude (in meters).
+     */
     rpc SetReturnToLaunchAltitude(SetReturnToLaunchAltitudeRequest) returns(SetReturnToLaunchAltitudeResponse) {}
 }
 
@@ -71,11 +147,11 @@ message TransitionToMulticopterResponse {
 message GetTakeoffAltitudeRequest {}
 message GetTakeoffAltitudeResponse {
     ActionResult action_result = 1;
-    float altitude = 2;
+    float altitude = 2; // Takeoff altitude relative to ground/takeoff location (in meters)
 }
 
 message SetTakeoffAltitudeRequest {
-    float altitude = 1;
+    float altitude = 1; // Takeoff altitude relative to ground/takeoff location (in meters)
 }
 message SetTakeoffAltitudeResponse {
     ActionResult action_result = 1;
@@ -84,11 +160,11 @@ message SetTakeoffAltitudeResponse {
 message GetMaximumSpeedRequest {}
 message GetMaximumSpeedResponse {
     ActionResult action_result = 1;
-    float speed = 2;
+    float speed = 2; // Maximum speed (in metres/second)
 }
 
 message SetMaximumSpeedRequest {
-    float speed = 1;
+    float speed = 1; // Maximum speed (in metres/second)
 }
 message SetMaximumSpeedResponse {
     ActionResult action_result = 1;
@@ -97,32 +173,34 @@ message SetMaximumSpeedResponse {
 message GetReturnToLaunchAltitudeRequest {}
 message GetReturnToLaunchAltitudeResponse {
     ActionResult action_result = 1;
-    float relative_altitude_m = 2;
+    float relative_altitude_m = 2; // Return altitude relative to takeoff location (in meters)
 }
 
 message SetReturnToLaunchAltitudeRequest {
-    float relative_altitude_m = 1;
+    float relative_altitude_m = 1; // Return altitude relative to takeoff location (in meters)
 }
 message SetReturnToLaunchAltitudeResponse {
     ActionResult action_result = 1;
 }
 
+// Result type.
 message ActionResult {
+    // Possible results returned for action requests
     enum Result {
-        UNKNOWN = 0;
-        SUCCESS = 1;
-        NO_SYSTEM = 2;
-        CONNECTION_ERROR = 3;
-        BUSY = 4;
-        COMMAND_DENIED = 5;
-        COMMAND_DENIED_LANDED_STATE_UNKNOWN = 6;
-        COMMAND_DENIED_NOT_LANDED = 7;
-        TIMEOUT = 8;
-        VTOL_TRANSITION_SUPPORT_UNKNOWN = 9;
-        NO_VTOL_TRANSITION_SUPPORT = 10;
-        PARAMETER_ERROR = 11;
+        UNKNOWN = 0; // Unknown error
+        SUCCESS = 1; // Success. The action command was accepted by the vehicle
+        NO_SYSTEM = 2; // No system is connected
+        CONNECTION_ERROR = 3; // Connection error
+        BUSY = 4; // Vehicle is busy
+        COMMAND_DENIED = 5; // Command refused by vehicle
+        COMMAND_DENIED_LANDED_STATE_UNKNOWN = 6; // Command refused because landed state is unknown
+        COMMAND_DENIED_NOT_LANDED = 7; // Command refused because vehicle not landed
+        TIMEOUT = 8; // Request timed out
+        VTOL_TRANSITION_SUPPORT_UNKNOWN = 9; // Hybrid/VTOL transition refused because VTOL support is unknown
+        NO_VTOL_TRANSITION_SUPPORT = 10; // Vehicle does not support hybrid/VTOL transitions
+        PARAMETER_ERROR = 11; // Error getting or setting parameter
     }
 
-    Result result = 1;
-    string result_str = 2;
+    Result result = 1; // Result enum value
+    string result_str = 2; // Human-readable English string describing the result
 }

--- a/protos/calibration/calibration.proto
+++ b/protos/calibration/calibration.proto
@@ -5,64 +5,77 @@ package mavsdk.rpc.calibration;
 option java_package = "io.mavsdk.calibration";
 option java_outer_classname = "CalibrationProto";
 
+// Enable to calibrate sensors of a drone such as gyro, accelerometer, and magnetometer.
 service CalibrationService {
+    // Perform gyro calibration.
     rpc SubscribeCalibrateGyro(SubscribeCalibrateGyroRequest) returns(stream CalibrateGyroResponse) {}
+    // Perform accelerometer calibration.
     rpc SubscribeCalibrateAccelerometer(SubscribeCalibrateAccelerometerRequest) returns(stream CalibrateAccelerometerResponse) {}
+    // Perform magnetometer caliration.
     rpc SubscribeCalibrateMagnetometer(SubscribeCalibrateMagnetometerRequest) returns(stream CalibrateMagnetometerResponse) {}
+    // Perform gimbal accelerometer calibration.
     rpc SubscribeCalibrateGimbalAccelerometer(SubscribeCalibrateGimbalAccelerometerRequest) returns(stream CalibrateGimbalAccelerometerResponse) {}
+    // Cancel ongoing calibration process.
     rpc Cancel(CancelRequest) returns(CancelResponse) {}
 }
 
 message SubscribeCalibrateGyroRequest {}
 message CalibrateGyroResponse {
     CalibrationResult calibration_result = 1;
-    ProgressData progress_data = 2;
+    ProgressData progress_data = 2; // Progress data
 }
 
 message SubscribeCalibrateAccelerometerRequest {}
 message CalibrateAccelerometerResponse {
     CalibrationResult calibration_result = 1;
-    ProgressData progress_data = 2;
+    ProgressData progress_data = 2; // Progress data
 }
 
 message SubscribeCalibrateMagnetometerRequest {}
 message CalibrateMagnetometerResponse {
     CalibrationResult calibration_result = 1;
-    ProgressData progress_data = 2;
+    ProgressData progress_data = 2; // Progress data
 }
 
 message SubscribeCalibrateGimbalAccelerometerRequest {}
 message CalibrateGimbalAccelerometerResponse {
     CalibrationResult calibration_result = 1;
-    ProgressData progress_data = 2;
+    ProgressData progress_data = 2; // Progress data
 }
 
 message CancelRequest {}
 message CancelResponse {}
 
+// Result type.
 message CalibrationResult {
+    // Possible results returned for calibration commands
     enum Result {
-        UNKNOWN = 0;
-        SUCCESS = 1;
-        IN_PROGRESS = 2;
-        INSTRUCTION = 3;
-        FAILED = 4;
-        NO_SYSTEM = 5;
-        CONNECTION_ERROR = 6;
-        BUSY = 7;
-        COMMAND_DENIED = 8;
-        TIMEOUT = 9;
-        CANCELLED = 10;
+        UNKNOWN = 0; // Unknown error
+        SUCCESS = 1; // The calibration process succeeded
+        IN_PROGRESS = 2; // Intermediate message showing progress of the calibration process
+        INSTRUCTION = 3; // Intermediate message giving instructions on the next steps required by the process
+        FAILED = 4; // Calibration failed
+        NO_SYSTEM = 5; // No system is connected
+        CONNECTION_ERROR = 6; // Connection error
+        BUSY = 7; // Vehicle is busy
+        COMMAND_DENIED = 8; // Command refused by vehicle
+        TIMEOUT = 9; // Command timed out
+        CANCELLED = 10; // Calibration process got cancelled
     }
 
-    Result result = 1;
-    string result_str = 2;
+    Result result = 1; // Result enum value
+    string result_str = 2; // Human-readable English string describing the result
 }
 
+/*
+ * Progress data coming from calibration.
+ *
+ * Can be a progress percentage, or an instruction text.
+ */
 message ProgressData {
     bool has_progress = 1;
-    float progress = 2;
+    float progress = 2; // Progress (percentage)
 
     bool has_status_text = 3;
-    string status_text = 4;
+    string status_text = 4; // Instruction text
 }

--- a/protos/camera/camera.proto
+++ b/protos/camera/camera.proto
@@ -5,21 +5,75 @@ package mavsdk.rpc.camera;
 option java_package = "io.mavsdk.camera";
 option java_outer_classname = "CameraProto";
 
+/*
+ * Can be used to manage cameras that implement the MAVLink
+ * Camera Protocol: https://mavlink.io/en/protocol/camera.html.
+ *
+ * Currently only a single camera is supported.
+ * When multiple cameras are supported the plugin will need to be
+ * instantiated separately for every camera and the camera selected using
+ * `select_camera`.
+ */
 service CameraService {
+    /*
+     * Take one photo.
+     */
     rpc TakePhoto(TakePhotoRequest) returns(TakePhotoResponse) {}
+    /*
+     * Start photo timelapse with a given interval.
+     */
     rpc StartPhotoInterval(StartPhotoIntervalRequest) returns(StartPhotoIntervalResponse) {}
+    /*
+     * Stop a running photo timelapse.
+     */
     rpc StopPhotoInterval(StopPhotoIntervalRequest) returns(StopPhotoIntervalResponse) {}
+    /*
+     * Start a video recording.
+     */
     rpc StartVideo(StartVideoRequest) returns(StartVideoResponse) {}
+    /*
+     * Stop a running video recording.
+     */
     rpc StopVideo(StopVideoRequest) returns(StopVideoResponse) {}
+    /*
+     * Start video streaming.
+     */
     rpc StartVideoStreaming(StartVideoStreamingRequest) returns(StartVideoStreamingResponse) {}
+    /*
+     * Stop current video streaming.
+     */
     rpc StopVideoStreaming(StopVideoStreamingRequest) returns(StopVideoStreamingResponse) {}
+    /*
+     * Set camera mode.
+     */
     rpc SetMode(SetModeRequest) returns(SetModeResponse) {}
+    /*
+     * Subscribe to camera mode updates.
+     */
     rpc SubscribeMode(SubscribeModeRequest) returns(stream ModeResponse) {}
+    /*
+     * Subscribe to video stream info updates.
+     */
     rpc SubscribeVideoStreamInfo(SubscribeVideoStreamInfoRequest) returns(stream VideoStreamInfoResponse) {}
+    /*
+     * Subscribe to capture info updates.
+     */
     rpc SubscribeCaptureInfo(SubscribeCaptureInfoRequest) returns(stream CaptureInfoResponse) {}
+    /*
+     * Subscribe to camera status updates.
+     */
     rpc SubscribeCameraStatus(SubscribeCameraStatusRequest) returns(stream CameraStatusResponse) {}
+    /*
+     * Get the list of current camera settings.
+     */
     rpc SubscribeCurrentSettings(SubscribeCurrentSettingsRequest) returns(stream CurrentSettingsResponse) {}
+    /*
+     * Get the list of settings that can be changed.
+     */
     rpc SubscribePossibleSettingOptions(SubscribePossibleSettingOptionsRequest) returns(stream PossibleSettingOptionsResponse) {}
+    /*
+     * Set a setting to some value.
+     */
     rpc SetSetting(SetSettingRequest) returns(SetSettingResponse) {}
 }
 
@@ -29,7 +83,7 @@ message TakePhotoResponse {
 }
 
 message StartPhotoIntervalRequest {
-    float interval_s = 1;
+    float interval_s = 1; // Interval between photos (in seconds)
 }
 message StartPhotoIntervalResponse {
     CameraResult camera_result = 1;
@@ -61,7 +115,7 @@ message StopVideoStreamingResponse {
 }
 
 message SetModeRequest {
-    CameraMode camera_mode = 1;
+    CameraMode camera_mode = 1; // Camera mode to set
 }
 message SetModeResponse {
     CameraResult camera_result = 1;
@@ -69,144 +123,174 @@ message SetModeResponse {
 
 message SubscribeModeRequest {}
 message ModeResponse {
-    CameraMode camera_mode = 1;
+    CameraMode camera_mode = 1; // Camera mode
 }
 
 message SubscribeVideoStreamInfoRequest {}
 message VideoStreamInfoResponse {
-    VideoStreamInfo video_stream_info = 1;
+    VideoStreamInfo video_stream_info = 1; // Video stream info
 }
 
 message SubscribeCaptureInfoRequest {}
 message CaptureInfoResponse {
-    CaptureInfo capture_info = 1;
+    CaptureInfo capture_info = 1; // Capture info
 }
 
 message SubscribeCameraStatusRequest {}
 message CameraStatusResponse {
-    CameraStatus camera_status = 1;
+    CameraStatus camera_status = 1; // Camera status
 }
 
 message SubscribeCurrentSettingsRequest {}
 message CurrentSettingsResponse {
-    repeated Setting current_settings = 1;
+    repeated Setting current_settings = 1; // List of current settings
 }
 
 message SubscribePossibleSettingOptionsRequest {}
 message PossibleSettingOptionsResponse {
-    repeated SettingOptions setting_options = 1;
+    repeated SettingOptions setting_options = 1; // List of settings that can be changed
 }
 
 message SetSettingRequest {
-    Setting setting = 1;
+    Setting setting = 1; // Desired setting
 }
 message SetSettingResponse {
     CameraResult camera_result = 1;
 }
 
+// Result type.
 message CameraResult {
+    // Possible results returned for camera commands
     enum Result {
-        UNKNOWN = 0;
-        SUCCESS = 1;
-        IN_PROGRESS = 2;
-        BUSY = 3;
-        DENIED = 4;
-        ERROR = 5;
-        TIMEOUT = 6;
-        WRONG_ARGUMENT = 7;
+        UNKNOWN = 0; // Unknown error
+        SUCCESS = 1; // Command executed successfully
+        IN_PROGRESS = 2; // Command in progress
+        BUSY = 3; // Camera is busy and rejected command
+        DENIED = 4; // Camera denied the command
+        ERROR = 5; // An error has occured while executing the command
+        TIMEOUT = 6; // Command timed out
+        WRONG_ARGUMENT = 7; // Command has wrong argument(s)
     }
 
-    Result result = 1;
-    string result_str = 2;
+    Result result = 1; // Result enum value
+    string result_str = 2; // Human-readable English string describing the result
 }
 
+// Camera mode type.
 enum CameraMode {
-    UNKNOWN = 0;
-    PHOTO = 1;
-    VIDEO = 2;
+    UNKNOWN = 0; // Unknown
+    PHOTO = 1; // Photo mode
+    VIDEO = 2; // Video mode
 }
 
+// Information about a picture just captured.
 message CaptureInfo {
-    Position position = 1;
-    Quaternion attitude_quaternion = 2;
-    EulerAngle attitude_euler_angle = 3;
-    uint64 time_utc_us = 4;
-    bool is_success = 5;
-    int32 index = 6;
-    string file_url = 7;
+    Position position = 1; // Location where the picture was taken
+    Quaternion attitude_quaternion = 2; // Attitude of the camera when the picture was taken (quaternion)
+    EulerAngle attitude_euler_angle = 3; // Attitude of the camera when the picture was taken (euler angle)
+    uint64 time_utc_us = 4; // Timestamp in UTC (since UNIX epoch) in microseconds
+    bool is_success = 5; // True if the capture was successful
+    int32 index = 6; // Zero-based index of this image since vehicle was armed
+    string file_url = 7; // Download URL of this image
 }
 
+// Position type in global coordinates.
 message Position {
-    double latitude_deg = 1;
-    double longitude_deg = 2;
-    float absolute_altitude_m = 3;
-    float relative_altitude_m = 4;
+    double latitude_deg = 1; // Latitude in degrees (range: -90 to +90)
+    double longitude_deg = 2; // Longitude in degrees (range: -180 to +180)
+    float absolute_altitude_m = 3; // Altitude AMSL (above mean sea level) in metres
+    float relative_altitude_m = 4; // Altitude relative to takeoff altitude in metres
 }
 
+/*
+ * Quaternion type.
+ *
+ * All rotations and axis systems follow the right-hand rule.
+ * The Hamilton quaternion product definition is used.
+ * A zero-rotation quaternion is represented by (1,0,0,0).
+ * The quaternion could also be written as w + xi + yj + zk.
+ *
+ * For more info see: https://en.wikipedia.org/wiki/Quaternion
+ */
 message Quaternion {
-    float w = 1;
-    float x = 2;
-    float y = 3;
-    float z = 4;
+    float w = 1; // Quaternion entry 0, also denoted as a
+    float x = 2; // Quaternion entry 1, also denoted as b
+    float y = 3; // Quaternion entry 2, also denoted as c
+    float z = 4; // Quaternion entry 3, also denoted as d
 }
 
+/*
+ * Euler angle type.
+ *
+ * All rotations and axis systems follow the right-hand rule.
+ * The Euler angles follow the convention of a 3-2-1 intrinsic Tait-Bryan rotation sequence.
+ *
+ * For more info see https://en.wikipedia.org/wiki/Euler_angles
+ */
 message EulerAngle {
-    float roll_deg = 1;
-    float pitch_deg = 2;
-    float yaw_deg = 3;
+    float roll_deg = 1; // Roll angle in degrees, positive is banking to the right
+    float pitch_deg = 2; // Pitch angle in degrees, positive is pitching nose up
+    float yaw_deg = 3; // Yaw angle in degrees, positive is clock-wise seen from above
 }
 
+// Type for video stream settings.
 message VideoStreamSettings {
-    float frame_rate_hz = 1;
-    uint32 horizontal_resolution_pix = 2;
-    uint32 vertical_resolution_pix = 3;
-    uint32 bit_rate_b_s = 4;
-    uint32 rotation_deg = 5;
-    string uri = 6;
+    float frame_rate_hz = 1; // Frames per second
+    uint32 horizontal_resolution_pix = 2; // Horizontal resolution (in pixels)
+    uint32 vertical_resolution_pix = 3; // Vertical resolution (in pixels)
+    uint32 bit_rate_b_s = 4; // Bit rate (in bits per second)
+    uint32 rotation_deg = 5; // Video image rotation (clockwise, 0-359 degrees)
+    string uri = 6; // Video stream URI
 }
 
+// Information about the video stream.
 message VideoStreamInfo {
     enum VideoStreamStatus {
-        NOT_RUNNING = 0;
-        IN_PROGRESS = 1;
+        NOT_RUNNING = 0; // Video stream is not running.
+        IN_PROGRESS = 1; // Video stream is running.
     }
 
-    VideoStreamSettings video_stream_settings = 1;
-    VideoStreamStatus video_stream_status = 2;
+    VideoStreamSettings video_stream_settings = 1; // Video stream settings
+    VideoStreamStatus video_stream_status = 2; // Current status of video streaming
 }
 
+// Information about the camera status.
 message CameraStatus {
+    // Storage status type.
     enum StorageStatus {
-        NOT_AVAILABLE = 0;
-        UNFORMATTED = 1;
-        FORMATTED = 2;
+        NOT_AVAILABLE = 0; // Status not available
+        UNFORMATTED = 1; // Storage is not formatted (i.e. has no recognized file system)
+        FORMATTED = 2; // Storage is formatted (i.e. has recognized a file system)
     }
 
     bool video_on = 1;
     bool photo_interval_on = 2;
 
-    float used_storage_mib = 3;
-    float available_storage_mib = 4;
-    float total_storage_mib = 5;
-    float recording_time_s = 6;
-    string media_folder_name = 7;
+    float used_storage_mib = 3; // Used storage (in MiB)
+    float available_storage_mib = 4; // Available storage (in MiB)
+    float total_storage_mib = 5; // Total storage (in MiB)
+    float recording_time_s = 6; // Elapsed time since starting the video recording (in seconds)
+    string media_folder_name = 7; // Current folder name where media are saved
 
-    StorageStatus storage_status = 8;
+    StorageStatus storage_status = 8; // Storage status
 }
 
+// Type to represent a setting with a selected option.
 message Setting {
-    string setting_id = 1;
-    string setting_description = 2;
-    Option option = 3;
+    string setting_id = 1; // Name of a setting (machine readable)
+    string setting_description = 2; // Description of the setting (human readable)
+    Option option = 3; // Selected option
 }
 
+// Type to represent a setting option.
 message Option {
-    string option_id = 1;
-    string option_description = 2;
+    string option_id = 1; // Name of the option (machine readable)
+    string option_description = 2; // Description of the option (human readable)
 }
 
+// Type to represent a setting with a list of options to choose from.
 message SettingOptions {
-    string setting_id = 1;
-    string setting_description = 2;
-    repeated Option options = 3;
+    string setting_id = 1; // Name of the setting (machine readable)
+    string setting_description = 2; // Description of the setting (human readable)
+    repeated Option options = 3; // List of options
 }

--- a/protos/param/param.proto
+++ b/protos/param/param.proto
@@ -5,56 +5,80 @@ package mavsdk.rpc.param;
 option java_package = "io.mavsdk.param";
 option java_outer_classname = "ParamProto";
 
+// Provide raw access to get and set parameters.
 service ParamService {
- rpc GetIntParam(GetIntParamRequest) returns(GetIntParamResponse) {}
- rpc SetIntParam(SetIntParamRequest) returns(SetIntParamResponse) {}
- rpc GetFloatParam(GetFloatParamRequest) returns(GetFloatParamResponse) {}
- rpc SetFloatParam(SetFloatParamRequest) returns(SetFloatParamResponse) {}
+    /*
+     * Get an int parameter.
+     *
+     * If the type is wrong, the result will be `WRONG_TYPE`.
+     */
+    rpc GetIntParam(GetIntParamRequest) returns(GetIntParamResponse) {}
+    /*
+     * Set an int parameter.
+     *
+     * If the type is wrong, the result will be `WRONG_TYPE`.
+     */
+    rpc SetIntParam(SetIntParamRequest) returns(SetIntParamResponse) {}
+    /*
+     * Get a float parameter.
+     *
+     * If the type is wrong, the result will be `WRONG_TYPE`.
+     */
+    rpc GetFloatParam(GetFloatParamRequest) returns(GetFloatParamResponse) {}
+    /*
+     * Set a float parameter.
+     *
+     * If the type is wrong, the result will be `WRONG_TYPE`.
+     */
+    rpc SetFloatParam(SetFloatParamRequest) returns(SetFloatParamResponse) {}
 }
 
 message GetIntParamRequest {
-    string name = 1;
+    string name = 1; // Name of the parameter
 }
+
 message GetIntParamResponse {
     ParamResult param_result = 1;
-    int32 value = 2;
+    int32 value = 2; // Value of the requested parameter
 }
 
 message SetIntParamRequest {
-    string name = 1;
-    int32 value = 2;
+    string name = 1; // Name of the parameter to set
+    int32 value = 2; // Value the parameter should be set to
 }
 message SetIntParamResponse {
     ParamResult param_result = 1;
 }
 
 message GetFloatParamRequest {
-    string name = 1;
+    string name = 1; // Name of the parameter
 }
 message GetFloatParamResponse {
     ParamResult param_result = 1;
-    float value = 2;
+    float value = 2; // Value of the requested parameter
 }
 
 message SetFloatParamRequest {
-    string name = 1;
-    float value = 2;
+    string name = 1; // Name of the parameter to set
+    float value = 2; // Value the parameter should be set to
 }
 message SetFloatParamResponse {
     ParamResult param_result = 1;
 }
 
+// Result type.
 message ParamResult {
+    // Possible results returned for param requests.
     enum Result {
-        UNKNOWN = 0;
-        SUCCESS = 1;
-        TIMEOUT = 2;
-        CONNECTION_ERROR = 3;
-        WRONG_TYPE = 4;
-        PARAM_NAME_TOO_LONG = 5;
+        UNKNOWN = 0; // Unknown error
+        SUCCESS = 1; // Request succeeded
+        TIMEOUT = 2; // Request timed out
+        CONNECTION_ERROR = 3; // Connection error
+        WRONG_TYPE = 4; // Wrong type
+        PARAM_NAME_TOO_LONG = 5; // Parameter name too long (> 16)
     }
 
-    Result result = 1;
-    string result_str = 2;
+    Result result = 1; // Result enum value
+    string result_str = 2; // Human-readable English string describing the result
 }
 

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -5,22 +5,42 @@ package mavsdk.rpc.telemetry;
 option java_package = "io.mavsdk.telemetry";
 option java_outer_classname = "TelemetryProto";
 
+/*
+ * Allow users to get vehicle telemetry and state information
+ * (e.g. battery, GPS, RC connection, flight mode etc.) and set telemetry update rates.
+ */
 service TelemetryService {
+    // Subscribe to 'position' updates.
     rpc SubscribePosition(SubscribePositionRequest) returns(stream PositionResponse) {}
+    // Subscribe to 'home position' updates.
     rpc SubscribeHome(SubscribeHomeRequest) returns(stream HomeResponse) {}
+    // Subscribe to in-air updates.
     rpc SubscribeInAir(SubscribeInAirRequest) returns(stream InAirResponse) {}
+    // Subscribe to armed updates.
     rpc SubscribeArmed(SubscribeArmedRequest) returns(stream ArmedResponse) {}
+    // Subscribe to 'attitude' updates (quaternion).
     rpc SubscribeAttitudeQuaternion(SubscribeAttitudeQuaternionRequest) returns(stream AttitudeQuaternionResponse) {}
+    // Subscribe to 'attitude' updates (euler).
     rpc SubscribeAttitudeEuler(SubscribeAttitudeEulerRequest) returns(stream AttitudeEulerResponse) {}
+    // Subscribe to 'attitude' updates (angular velocity)
     rpc SubscribeAttitudeAngularVelocityBody(SubscribeAttitudeAngularVelocityBodyRequest) returns(stream AttitudeAngularVelocityBodyResponse) {}
+    // Subscribe to 'camera attitude' updates (quaternion).
     rpc SubscribeCameraAttitudeQuaternion(SubscribeCameraAttitudeQuaternionRequest) returns(stream CameraAttitudeQuaternionResponse) {}
+    // Subscribe to 'camera attitude' updates (euler).
     rpc SubscribeCameraAttitudeEuler(SubscribeCameraAttitudeEulerRequest) returns(stream CameraAttitudeEulerResponse) {}
+    // Subscribe to 'ground speed' updates (NED).
     rpc SubscribeGroundSpeedNed(SubscribeGroundSpeedNedRequest) returns(stream GroundSpeedNedResponse) {}
+    // Subscribe to 'GPS info' updates.
     rpc SubscribeGpsInfo(SubscribeGpsInfoRequest) returns(stream GpsInfoResponse) {}
+    // Subscribe to 'battery' updates.
     rpc SubscribeBattery(SubscribeBatteryRequest) returns(stream BatteryResponse) {}
+    // Subscribe to 'flight mode' updates.
     rpc SubscribeFlightMode(SubscribeFlightModeRequest) returns(stream FlightModeResponse) {}
+    // Subscribe to 'health' updates.
     rpc SubscribeHealth(SubscribeHealthRequest) returns(stream HealthResponse) {}
+    // Subscribe to 'RC status' updates.
     rpc SubscribeRcStatus(SubscribeRcStatusRequest) returns(stream RcStatusResponse) {}
+    // Subscribe to 'status text' updates.
     rpc SubscribeStatusText(SubscribeStatusTextRequest) returns(stream StatusTextResponse) {}
     rpc SubscribeActuatorControlTarget(SubscribeActuatorControlTargetRequest) returns(stream ActuatorControlTargetResponse) {}
     rpc SubscribeActuatorOutputStatus(SubscribeActuatorOutputStatusRequest) returns(stream ActuatorOutputStatusResponse) {}
@@ -28,32 +48,32 @@ service TelemetryService {
 
 message SubscribePositionRequest {}
 message PositionResponse {
-    Position position = 1;
+    Position position = 1; // The next position
 }
 
 message SubscribeHomeRequest {}
 message HomeResponse {
-    Position home = 1;
+    Position home = 1; // The next home position
 }
 
 message SubscribeInAirRequest {}
 message InAirResponse {
-    bool is_in_air = 1;
+    bool is_in_air = 1; // The next 'in-air' state
 }
 
 message SubscribeArmedRequest {}
 message ArmedResponse {
-   bool is_armed = 1;
+   bool is_armed = 1; // The next 'armed' state
 }
 
 message SubscribeAttitudeQuaternionRequest {}
 message AttitudeQuaternionResponse {
-    Quaternion attitude_quaternion = 1;
+    Quaternion attitude_quaternion = 1; // The next attitude (quaternion)
 }
 
 message SubscribeAttitudeEulerRequest {}
 message AttitudeEulerResponse {
-    EulerAngle attitude_euler = 1;
+    EulerAngle attitude_euler = 1; // The next attitude (euler)
 }
 
 message SubscribeAttitudeAngularVelocityBodyRequest {}
@@ -63,148 +83,182 @@ message AttitudeAngularVelocityBodyResponse {
 
 message SubscribeCameraAttitudeQuaternionRequest {}
 message CameraAttitudeQuaternionResponse {
-    Quaternion attitude_quaternion = 1;
+    Quaternion attitude_quaternion = 1; // The next camera attitude (quaternion)
 }
 
 message SubscribeCameraAttitudeEulerRequest {}
 message CameraAttitudeEulerResponse {
-    EulerAngle attitude_euler = 1;
+    EulerAngle attitude_euler = 1; // The next camera attitude (euler)
 }
 
 message SubscribeGroundSpeedNedRequest {}
 message GroundSpeedNedResponse {
-    SpeedNed ground_speed_ned = 1;
+    SpeedNed ground_speed_ned = 1; // The next ground speed (NED)
 }
 
 message SubscribeGpsInfoRequest {}
 message GpsInfoResponse {
-    GpsInfo gps_info = 1;
+    GpsInfo gps_info = 1; // The next 'GPS info' state
 }
 
 message SubscribeBatteryRequest {}
 message BatteryResponse {
-    Battery battery = 1;
+    Battery battery = 1; // The next 'battery' state
 }
 
 message SubscribeFlightModeRequest {}
 message FlightModeResponse {
-    FlightMode flight_mode = 1;
+    FlightMode flight_mode = 1; // The next flight mode
 }
 
 message SubscribeHealthRequest {}
 message HealthResponse {
-    Health health = 1;
+    Health health = 1; // The next 'health' state
 }
 
 message SubscribeRcStatusRequest {}
 message RcStatusResponse {
-    RcStatus rc_status = 1;
+    RcStatus rc_status = 1; // The next RC status
 }
 
 message SubscribeStatusTextRequest {}
 message StatusTextResponse {
-    StatusText status_text = 1;
+    StatusText status_text = 1; // The next 'status text'
 }
 
 message SubscribeActuatorControlTargetRequest {}
 message ActuatorControlTargetResponse {
-    ActuatorControlTarget actuator_control_target = 1;
+    ActuatorControlTarget actuator_control_target = 1; // Actuator control target
 }
 
 message SubscribeActuatorOutputStatusRequest {}
 message ActuatorOutputStatusResponse {
-    ActuatorOutputStatus actuator_output_status = 1;
+    ActuatorOutputStatus actuator_output_status = 1; // Actuator output status
 }
 
+// Position type in global coordinates.
 message Position {
-    double latitude_deg = 1;
-    double longitude_deg = 2;
-    float absolute_altitude_m = 3;
-    float relative_altitude_m = 4;
+    double latitude_deg = 1; // Latitude in degrees (range: -90 to +90)
+    double longitude_deg = 2; // Longitude in degrees (range: -180 to +180)
+    float absolute_altitude_m = 3; // Altitude AMSL (above mean sea level) in metres
+    float relative_altitude_m = 4; // Altitude relative to takeoff altitude in metres
 }
 
+/*
+ * Quaternion type.
+ *
+ * All rotations and axis systems follow the right-hand rule.
+ * The Hamilton quaternion product definition is used.
+ * A zero-rotation quaternion is represented by (1,0,0,0).
+ * The quaternion could also be written as w + xi + yj + zk.
+ *
+ * For more info see: https://en.wikipedia.org/wiki/Quaternion
+ */
 message Quaternion {
-    float w = 1;
-    float x = 2;
-    float y = 3;
-    float z = 4;
+    float w = 1; // Quaternion entry 0, also denoted as a
+    float x = 2; // Quaternion entry 1, also denoted as b
+    float y = 3; // Quaternion entry 2, also denoted as c
+    float z = 4; // Quaternion entry 3, also denoted as d
 }
 
+/*
+ * Euler angle type.
+ *
+ * All rotations and axis systems follow the right-hand rule.
+ * The Euler angles follow the convention of a 3-2-1 intrinsic Tait-Bryan rotation sequence.
+ *
+ * For more info see https://en.wikipedia.org/wiki/Euler_angles
+ */
 message EulerAngle {
-    float roll_deg = 1;
-    float pitch_deg = 2;
-    float yaw_deg = 3;
+    float roll_deg = 1; // Roll angle in degrees, positive is banking to the right
+    float pitch_deg = 2; // Pitch angle in degrees, positive is pitching nose up
+    float yaw_deg = 3; // Yaw angle in degrees, positive is clock-wise seen from above
 }
 
+// Angular velocity type
 message AngularVelocityBody {
-    float roll_rad_s = 1;
-    float pitch_rad_s = 2;
-    float yaw_rad_s = 3;
+    float roll_rad_s = 1; // Roll angular velocity
+    float pitch_rad_s = 2; // Pitch angular velocity
+    float yaw_rad_s = 3; // Yaw angular velocity
 }
 
+// Speed type, represented in the NED (North East Down) frame and in metres/second.
 message SpeedNed {
-    float velocity_north_m_s = 1;
-    float velocity_east_m_s = 2;
-    float velocity_down_m_s = 3;
+    float velocity_north_m_s = 1; // Velocity in North direction in metres/second
+    float velocity_east_m_s = 2; // Velocity in East direction in metres/second
+    float velocity_down_m_s = 3; // Velocity in Down direction in metres/second
 }
 
+// GPS information type.
 message GpsInfo {
-    int32 num_satellites = 1;
-    FixType fix_type = 2;
+    int32 num_satellites = 1; // Number of visible satellites in use
+    FixType fix_type = 2; // Fix type
 }
 
+// Fix type.
 enum FixType {
-    NO_GPS = 0;
-    NO_FIX = 1;
-    FIX_2D = 2;
-    FIX_3D = 3;
-    FIX_DGPS = 4;
-    RTK_FLOAT = 5;
-    RTK_FIXED = 6;
+    NO_GPS = 0; // No GPS connected
+    NO_FIX = 1; // No position information, GPS is connected
+    FIX_2D = 2; // 2D position
+    FIX_3D = 3; // 3D position
+    FIX_DGPS = 4; // DGPS/SBAS aided 3D position
+    RTK_FLOAT = 5; // RTK float, 3D position
+    RTK_FIXED = 6; // RTK Fixed, 3D position
 }
 
+// Battery type.
 message Battery {
-    float voltage_v = 1;
-    float remaining_percent = 2;
+    float voltage_v = 1; // Voltage in volts
+    float remaining_percent = 2; // Estimated battery remaining (range: 0.0 to 1.0)
 }
 
+/*
+ * Flight modes.
+ *
+ * For more information about flight modes, check out
+ * https://docs.px4.io/en/config/flight_mode.html.
+ */
 enum FlightMode {
-    UNKNOWN = 0;
-    READY = 1;
-    TAKEOFF = 2;
-    HOLD = 3;
-    MISSION = 4;
-    RETURN_TO_LAUNCH = 5;
-    LAND = 6;
-    OFFBOARD = 7;
-    FOLLOW_ME = 8;
+    UNKNOWN = 0; // Mode not known
+    READY = 1; // Armed and ready to take off
+    TAKEOFF = 2; // Taking off
+    HOLD = 3; // Holding (hovering in place (or circling for fixed-wing vehicles)
+    MISSION = 4; // In mission
+    RETURN_TO_LAUNCH = 5; // Returning to launch position (then landing)
+    LAND = 6; // Landing
+    OFFBOARD = 7; // In 'offboard' mode
+    FOLLOW_ME = 8; // In 'follow-me' mode
 }
 
+// Health type.
 message Health {
-    bool is_gyrometer_calibration_ok = 1;
-    bool is_accelerometer_calibration_ok = 2;
-    bool is_magnetometer_calibration_ok = 3;
-    bool is_level_calibration_ok = 4;
-    bool is_local_position_ok = 5;
-    bool is_global_position_ok = 6;
-    bool is_home_position_ok = 7;
+    bool is_gyrometer_calibration_ok = 1; // True if the gyrometer is calibrated
+    bool is_accelerometer_calibration_ok = 2; // True if the accelerometer is calibrated
+    bool is_magnetometer_calibration_ok = 3; // True if the magnetometer is calibrated
+    bool is_level_calibration_ok = 4; // True if the vehicle has a valid level calibration
+    bool is_local_position_ok = 5; // True if the local position estimate is good enough to fly in 'position control' mode
+    bool is_global_position_ok = 6; // True if the global position estimate is good enough to fly in 'position control' mode
+    bool is_home_position_ok = 7; // True if the home position has been initialized properly
 }
 
+// Remote control status type.
 message RcStatus {
-    bool was_available_once = 1;
-    bool is_available = 2;
-    float signal_strength_percent = 3;
+    bool was_available_once = 1; // True if an RC signal has been available once
+    bool is_available = 2; // True if the RC signal is available now
+    float signal_strength_percent = 3; // Signal strength (range: 0 to 100)
 }
 
+// StatusText information type.
 message StatusText {
+    // Status types.
     enum StatusType {
-        INFO = 0;
-        WARNING = 1;
-        CRITICAL = 2;
+        INFO = 0; // Information or other
+        WARNING = 1; // Warning
+        CRITICAL = 2; // Critical
     }
-    
-    StatusType type = 1;
-    string text = 2;
+
+    StatusType type = 1; // Message type
+    string text = 2; // MAVLink status message
 }
 
 message ActuatorControlTarget {


### PR DESCRIPTION
Bring documentation from C++ to the proto files for a few plugins (action, calibration, camera, param, telemetry).

The other plugins will follow in a new PR soon.

@hamishwille: Those comments are the ones being parsed by #98 and used to generate language-specific documentation in the source files. I'll open a PR for the corresponding python templates as soon as those PRs are merged.