### PR TITLE
Revert "remove unused property"

### DIFF
--- a/pb_plugins/protoc_gen_dcsdk/type_info.py
+++ b/pb_plugins/protoc_gen_dcsdk/type_info.py
@@ -72,6 +72,24 @@ class TypeInfo:
             return self._default_types[type_id]
 
     @property
+    def parent_type(self):
+        """ Extracts parent type. This assumes that nesting is not deeper
+        than 1 level.
+
+        Note that it also assumes that the package name has 3 words. It
+        will start with a '.', giving something like:
+        '.io.mavlink.mavsdk.ActionResult.Result'."""
+        if self.is_primitive:
+            return None
+
+        type_tree = self._field.type_name.split(".")
+
+        if len(type_tree) <= 5:
+            return None
+
+        return str(type_tree[-2])
+
+    @property
     def is_result(self):
         """ Check if the field is a *Result """
         return self.name.endswith("Result")


### PR DESCRIPTION
This reverts commit b34da699d08a1e8c9376e3feb25433d128080798.

Removal of parent_type method in type_info.py will lead to syntax error in generated python codes after executing: ./other/tools/run_protoc.sh. The parent_type method is needed in struct.j2 (line 46 & 49), so it cannot be removed. 

Thanks