### PR TITLE
Fix package namespace for tune

### DIFF
--- a/protos/tune/tune.proto
+++ b/protos/tune/tune.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package mavsdk.rpc.geofence;
+package mavsdk.rpc.tune;
 
 option java_package = "io.mavsdk.tune";
 option java_outer_classname = "TuneProto";


### PR DESCRIPTION
Turns out the package for tune was set incorrectly, to geofence. I fixed it to mavsdk.rpc.tune so it generates correctly.