### PR TITLE
Field options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *__pycache__/
 *.pyc
 pb_plugins/generated/
+build/
+dist/

--- a/pb_plugins/protoc_gen_dcsdk/struct.py
+++ b/pb_plugins/protoc_gen_dcsdk/struct.py
@@ -36,10 +36,17 @@ class Struct(object):
 
         field_id = 0
         for field in pb_struct.field:
+
+            default_value = None
+            for field_descriptor in field.options.Extensions:
+                if field_descriptor.name == "default_value":
+                    default_value = field.options.Extensions[field_descriptor]
+
             self._fields.append(
                 Param(name_parser_factory.create(field.json_name),
                       type_info_factory.create(field),
-                      struct_docs['params'][field_id]) if struct_docs else None)
+                      default_value=default_value,
+                      description=struct_docs['params'][field_id]) if struct_docs else None)
 
             field_id += 1
 

--- a/pb_plugins/protoc_gen_dcsdk/utils.py
+++ b/pb_plugins/protoc_gen_dcsdk/utils.py
@@ -9,9 +9,10 @@ type_info_factory = TypeInfoFactory()
 
 
 class Param:
-    def __init__(self, name, type_info, description):
+    def __init__(self, name, type_info, default_value=None, description=None):
         self.name = name
         self.type_info = type_info
+        self.default_value = default_value
         self.description = description
 
 


### PR DESCRIPTION
This extracts the `default_value` from `FieldOptions` in struct.py, and assigns it to the params. As a result, the default value can be accessed in jinja2 templates with `param.default_value`.