### PR TITLE
Replace IN_PROGRESS and INSTRUCTION with more general NEXT

### DIFF
--- a/protos/calibration/calibration.proto
+++ b/protos/calibration/calibration.proto
@@ -54,15 +54,14 @@ message CalibrationResult {
     enum Result {
         RESULT_UNKNOWN = 0; // Unknown error
         RESULT_SUCCESS = 1; // The calibration process succeeded
-        RESULT_IN_PROGRESS = 2; // Intermediate message showing progress of the calibration process
-        RESULT_INSTRUCTION = 3; // Intermediate message giving instructions on the next steps required by the process
-        RESULT_FAILED = 4; // Calibration failed
-        RESULT_NO_SYSTEM = 5; // No system is connected
-        RESULT_CONNECTION_ERROR = 6; // Connection error
-        RESULT_BUSY = 7; // Vehicle is busy
-        RESULT_COMMAND_DENIED = 8; // Command refused by vehicle
-        RESULT_TIMEOUT = 9; // Command timed out
-        RESULT_CANCELLED = 10; // Calibration process got cancelled
+        RESULT_NEXT = 2; // Intermediate message showing progress or instructions on the next steps required by the process
+        RESULT_FAILED = 3; // Calibration failed
+        RESULT_NO_SYSTEM = 4; // No system is connected
+        RESULT_CONNECTION_ERROR = 5; // Connection error
+        RESULT_BUSY = 6; // Vehicle is busy
+        RESULT_COMMAND_DENIED = 7; // Command refused by vehicle
+        RESULT_TIMEOUT = 8; // Command timed out
+        RESULT_CANCELLED = 9; // Calibration process got cancelled
     }
 
     Result result = 1; // Result enum value


### PR DESCRIPTION
Tested to work with MAVSDK-Python (after corresponding changes)