### PR TITLE
MissionResult -> MissionRawResult

### DIFF
--- a/protos/mission_raw/mission_raw.proto
+++ b/protos/mission_raw/mission_raw.proto
@@ -73,45 +73,45 @@ message UploadMissionRequest {
     repeated MissionItem mission_items = 1; // The mission items
 }
 message UploadMissionResponse {
-    MissionResult mission_result = 1;
+    MissionRawResult mission_raw_result = 1;
 }
 
 message CancelMissionUploadRequest {}
 message CancelMissionUploadResponse {
-    MissionResult mission_result = 1;
+    MissionRawResult mission_raw_result = 1;
 }
 
 message DownloadMissionRequest {}
 message DownloadMissionResponse {
-    MissionResult mission_result = 1;
+    MissionRawResult mission_raw_result = 1;
     repeated MissionItem mission_items = 2; // The mission items
 }
 
 message CancelMissionDownloadRequest {}
 message CancelMissionDownloadResponse {
-    MissionResult mission_result = 1;
+    MissionRawResult mission_raw_result = 1;
 }
 
 message StartMissionRequest {}
 message StartMissionResponse {
-    MissionResult mission_result = 1;
+    MissionRawResult mission_raw_result = 1;
 }
 
 message PauseMissionRequest {}
 message PauseMissionResponse {
-    MissionResult mission_result = 1;
+    MissionRawResult mission_raw_result = 1;
 }
 
 message ClearMissionRequest {}
 message ClearMissionResponse {
-    MissionResult mission_result = 1;
+    MissionRawResult mission_raw_result = 1;
 }
 
 message SetCurrentMissionItemRequest {
     int32 index = 1; // Index of the mission item to be set as the next one (0-based)
 }
 message SetCurrentMissionItemResponse {
-    MissionResult mission_result = 1;
+    MissionRawResult mission_raw_result = 1;
 }
 
 message SubscribeMissionProgressRequest {}
@@ -148,7 +148,7 @@ message MissionItem {
 }
 
 // Result type.
-message MissionResult {
+message MissionRawResult {
     // Possible results returned for action requests.
     enum Result {
         RESULT_UNKNOWN = 0; // Unknown error


### PR DESCRIPTION
The templates in some languages (here Java) expect `*Result` to be formatted like `{{ plugin_name.upper_camel_case }}Result`.