### PR TITLE
Add 'is_finite' option to methods

### DIFF
--- a/pb_plugins/protoc_gen_dcsdk/mavsdk_options_pb2.py
+++ b/pb_plugins/protoc_gen_dcsdk/mavsdk_options_pb2.py
@@ -19,8 +19,8 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='mavsdk_options.proto',
   package='mavsdk.options',
   syntax='proto3',
-  serialized_options=None,
-  serialized_pb=b'\n\x14mavsdk_options.proto\x12\x0emavsdk.options\x1a google/protobuf/descriptor.proto**\n\tAsyncType\x12\t\n\x05\x41SYNC\x10\x00\x12\x08\n\x04SYNC\x10\x01\x12\x08\n\x04\x42OTH\x10\x02:6\n\rdefault_value\x12\x1d.google.protobuf.FieldOptions\x18\xd0\x86\x03 \x01(\t:0\n\x07\x65psilon\x12\x1d.google.protobuf.FieldOptions\x18\xd1\x86\x03 \x01(\x01:O\n\nasync_type\x12\x1e.google.protobuf.MethodOptions\x18\xd0\x86\x03 \x01(\x0e\x32\x19.mavsdk.options.AsyncTypeb\x06proto3'
+  serialized_options=b'\n\016options.mavsdk',
+  serialized_pb=b'\n\x14mavsdk_options.proto\x12\x0emavsdk.options\x1a google/protobuf/descriptor.proto**\n\tAsyncType\x12\t\n\x05\x41SYNC\x10\x00\x12\x08\n\x04SYNC\x10\x01\x12\x08\n\x04\x42OTH\x10\x02:6\n\rdefault_value\x12\x1d.google.protobuf.FieldOptions\x18\xd0\x86\x03 \x01(\t:0\n\x07\x65psilon\x12\x1d.google.protobuf.FieldOptions\x18\xd1\x86\x03 \x01(\x01:O\n\nasync_type\x12\x1e.google.protobuf.MethodOptions\x18\xd0\x86\x03 \x01(\x0e\x32\x19.mavsdk.options.AsyncType:3\n\tis_finite\x12\x1e.google.protobuf.MethodOptions\x18\xd1\x86\x03 \x01(\x08\x42\x10\n\x0eoptions.mavsdkb\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_descriptor__pb2.DESCRIPTOR,])
 
@@ -79,16 +79,27 @@ async_type = _descriptor.FieldDescriptor(
   message_type=None, enum_type=None, containing_type=None,
   is_extension=True, extension_scope=None,
   serialized_options=None, file=DESCRIPTOR)
+IS_FINITE_FIELD_NUMBER = 50001
+is_finite = _descriptor.FieldDescriptor(
+  name='is_finite', full_name='mavsdk.options.is_finite', index=3,
+  number=50001, type=8, cpp_type=7, label=1,
+  has_default_value=False, default_value=False,
+  message_type=None, enum_type=None, containing_type=None,
+  is_extension=True, extension_scope=None,
+  serialized_options=None, file=DESCRIPTOR)
 
 DESCRIPTOR.enum_types_by_name['AsyncType'] = _ASYNCTYPE
 DESCRIPTOR.extensions_by_name['default_value'] = default_value
 DESCRIPTOR.extensions_by_name['epsilon'] = epsilon
 DESCRIPTOR.extensions_by_name['async_type'] = async_type
+DESCRIPTOR.extensions_by_name['is_finite'] = is_finite
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(default_value)
 google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(epsilon)
 async_type.enum_type = _ASYNCTYPE
 google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(async_type)
+google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(is_finite)
 
+DESCRIPTOR._options = None
 # @@protoc_insertion_point(module_scope)

--- a/protos/calibration/calibration.proto
+++ b/protos/calibration/calibration.proto
@@ -10,13 +10,25 @@ option java_outer_classname = "CalibrationProto";
 // Enable to calibrate sensors of a drone such as gyro, accelerometer, and magnetometer.
 service CalibrationService {
     // Perform gyro calibration.
-    rpc SubscribeCalibrateGyro(SubscribeCalibrateGyroRequest) returns(stream CalibrateGyroResponse) { option (mavsdk.options.async_type) = ASYNC; }
+    rpc SubscribeCalibrateGyro(SubscribeCalibrateGyroRequest) returns(stream CalibrateGyroResponse) {
+        option (mavsdk.options.async_type) = ASYNC;
+        option (mavsdk.options.is_finite) = true;
+    }
     // Perform accelerometer calibration.
-    rpc SubscribeCalibrateAccelerometer(SubscribeCalibrateAccelerometerRequest) returns(stream CalibrateAccelerometerResponse) { option (mavsdk.options.async_type) = ASYNC; }
+    rpc SubscribeCalibrateAccelerometer(SubscribeCalibrateAccelerometerRequest) returns(stream CalibrateAccelerometerResponse) {
+        option (mavsdk.options.async_type) = ASYNC;
+        option (mavsdk.options.is_finite) = true;
+    }
     // Perform magnetometer caliration.
-    rpc SubscribeCalibrateMagnetometer(SubscribeCalibrateMagnetometerRequest) returns(stream CalibrateMagnetometerResponse) { option (mavsdk.options.async_type) = ASYNC; }
+    rpc SubscribeCalibrateMagnetometer(SubscribeCalibrateMagnetometerRequest) returns(stream CalibrateMagnetometerResponse) {
+        option (mavsdk.options.async_type) = ASYNC;
+        option (mavsdk.options.is_finite) = true;
+    }
     // Perform gimbal accelerometer calibration.
-    rpc SubscribeCalibrateGimbalAccelerometer(SubscribeCalibrateGimbalAccelerometerRequest) returns(stream CalibrateGimbalAccelerometerResponse) { option (mavsdk.options.async_type) = ASYNC; }
+    rpc SubscribeCalibrateGimbalAccelerometer(SubscribeCalibrateGimbalAccelerometerRequest) returns(stream CalibrateGimbalAccelerometerResponse) {
+        option (mavsdk.options.async_type) = ASYNC;
+        option (mavsdk.options.is_finite) = true;
+    }
     // Cancel ongoing calibration process.
     rpc Cancel(CancelRequest) returns(CancelResponse) { option (mavsdk.options.async_type) = SYNC; }
 }

--- a/protos/ftp/ftp.proto
+++ b/protos/ftp/ftp.proto
@@ -18,11 +18,17 @@ service FtpService {
     /*
      * Downloads a file to local directory.
      */
-    rpc SubscribeDownload(SubscribeDownloadRequest) returns(stream DownloadResponse) { option (mavsdk.options.async_type) = ASYNC; }
+    rpc SubscribeDownload(SubscribeDownloadRequest) returns(stream DownloadResponse) {
+        option (mavsdk.options.async_type) = ASYNC;
+        option (mavsdk.options.is_finite) = true;
+    }
     /*
      * Uploads local file to remote directory.
      */
-    rpc SubscribeUpload(SubscribeUploadRequest) returns(stream UploadResponse) { option (mavsdk.options.async_type) = ASYNC; }
+    rpc SubscribeUpload(SubscribeUploadRequest) returns(stream UploadResponse) {
+        option (mavsdk.options.async_type) = ASYNC;
+        option (mavsdk.options.is_finite) = true;
+    }
     /*
      * Lists items from a remote directory.
      */

--- a/protos/mavsdk_options.proto
+++ b/protos/mavsdk_options.proto
@@ -8,14 +8,12 @@ option java_package = "options.mavsdk";
 
 extend google.protobuf.FieldOptions {
     string default_value = 50000;
-}
-
-extend google.protobuf.FieldOptions {
     double epsilon = 50001;
 }
 
 extend google.protobuf.MethodOptions {
     AsyncType async_type = 50000;
+    bool is_finite = 50001;
 }
 
 enum AsyncType {


### PR DESCRIPTION
This enables specifying if a stream is finite or not. For instance for calibration, a stream is finite and therefore the generation function is `_async` (e.g. `calibrate_accelerometer_async`). For telemetry, a stream is infinite and becomes `subscribe_` (e.g. `subscribe_position`).

This has an impact on all the streams (they all become `subscribe_`) except for `Calibration` and `FTP` plugins.