### PR TITLE
minor fixes for MAVSDK-Java autogen

### DIFF
--- a/pb_plugins/protoc_gen_dcsdk/autogen.py
+++ b/pb_plugins/protoc_gen_dcsdk/autogen.py
@@ -32,7 +32,7 @@ class AutoGen(object):
             plugin_name, plugin_dir = AutoGen.extract_plugin_name_and_dir(
                 proto_file.name, package, is_java)
 
-            if package.startswith("google") or package == "mavsdk.options":
+            if package.startswith("google") or package == "mavsdk.options" or package.startswith("com.google") or package == "options.mavsdk":
                 continue
 
             docs = Docs.collect_docs(proto_file.source_code_info)

--- a/protos/log_files/log_files.proto
+++ b/protos/log_files/log_files.proto
@@ -21,7 +21,7 @@ service LogFilesService {
 
 message GetEntriesRequest {}
 message GetEntriesResponse {
-    LogFileResult log_file_result = 1;
+    LogFilesResult log_files_result = 1;
     repeated Entry entries = 2; // List of entries
 }
 
@@ -30,7 +30,7 @@ message SubscribeDownloadLogFileRequest {
     string path = 2; // Path of where to download log file to.
 }
 message DownloadLogFileResponse {
-    LogFileResult log_file_result = 1;
+    LogFilesResult log_files_result = 1;
     ProgressData progress = 2; // Progress if result is progress
 }
 
@@ -49,12 +49,12 @@ message Entry {
 }
 
 // Result type.
-message LogFileResult {
+message LogFilesResult {
     // Possible results returned for calibration commands
     enum Result {
         RESULT_UNKNOWN = 0; // Unknown result
         RESULT_SUCCESS = 1; // Request succeeded
-        RESULT_PROGRESS = 2; // Progress update
+        RESULT_NEXT = 2; // Progress update
         RESULT_NO_LOGFILES = 3; // No log files found
         RESULT_TIMEOUT = 4; // A timeout happened
         RESULT_INVALID_ARGUMENT = 5; // Invalid argument


### PR DESCRIPTION
* Java has different package names, so `autogen.py` needs to take that into account when ignoring files.
* The result type is hardcoded in Java, so it must be `<plugin_name.upper_camel_case>Result` in the proto file as well.
* The return name (here was `log_file_result` instead of `log_files_result`) should not require that, but it's faster to fix the Java autogen like this, and it doesn't hurt in the proto files.
* The languages bindings assume that a stream finishes on `SUCCESS`, gets an element on `NEXT`, and errors on everything else. Hence, `PROGRESS` is considered an error and should really be called `NEXT`.

Note that these changes should not have any influence in the compatibility between `mavsdk_server` and the language bindings: it's really just naming, but on the proto transport it uses the numbers, where `RESULT_NEXT = 2` and `RESULT_PROGRESS = 2` are encoded the same way. So these changes are not urgent and can come in the next `v0.25.1` release of `mavsdk_server`.