### PR TITLE
calibration: add RESULT_FAILED_ARMED

### DIFF
--- a/protos/calibration/calibration.proto
+++ b/protos/calibration/calibration.proto
@@ -74,6 +74,7 @@ message CalibrationResult {
         RESULT_COMMAND_DENIED = 7; // Command refused by vehicle
         RESULT_TIMEOUT = 8; // Command timed out
         RESULT_CANCELLED = 9; // Calibration process was cancelled
+        RESULT_FAILED_ARMED = 10; // Calibration process failed since the vehicle is armed
     }
 
     Result result = 1; // Result enum value


### PR DESCRIPTION
To notify on failure because the vehicle is armed. To address https://github.com/mavlink/MAVSDK/pull/1096#discussion_r423745374.