### PR TITLE
Rename `Type` to `FenceType`

### DIFF
--- a/protos/geofence/geofence.proto
+++ b/protos/geofence/geofence.proto
@@ -25,13 +25,13 @@ message Point {
 // Polygon type.
 message Polygon {
     // Geofence polygon types.
-    enum Type {
+    enum FenceType {
         TYPE_INCLUSION = 0; // Type representing an inclusion fence
         TYPE_EXCLUSION = 1; // Type representing an exclusion fence
     }
 
     repeated Point points = 1; // Points defining the polygon
-    Type type = 2; // Fence type
+    FenceType fence_type = 2; // Fence type
 }
 
 message UploadGeofenceRequest {


### PR DESCRIPTION
`Type` is a reserved word in Swift, so the proposition here is to avoid it. It could be dealt with, if really necessary, by using backticks around all the generated types. But in this case it feels like renaming it is not too bad.

It won't break protobuf compatibility, since it's just a name change.