### PR TITLE
Update offboard set velocity documentation

### DIFF
--- a/protos/offboard/offboard.proto
+++ b/protos/offboard/offboard.proto
@@ -55,11 +55,11 @@ service OffboardService {
      */
     rpc SetPositionNed(SetPositionNedRequest) returns(SetPositionNedResponse) { option (mavsdk.options.async_type) = SYNC; }
     /*
-     * Set the velocity in body coordinates and yaw angular rate.
+     * Set the velocity in body coordinates and yaw angular rate. Not available for fixed-wing aircraft.
      */
     rpc SetVelocityBody(SetVelocityBodyRequest) returns(SetVelocityBodyResponse) { option (mavsdk.options.async_type) = SYNC; }
     /*
-     * Set the velocity in NED coordinates and yaw.
+     * Set the velocity in NED coordinates and yaw. Not available for fixed-wing aircraft.
      */
     rpc SetVelocityNed(SetVelocityNedRequest) returns(SetVelocityNedResponse) { option (mavsdk.options.async_type) = SYNC; }
 }


### PR DESCRIPTION
https://github.com/mavlink/MAVSDK/issues/1154 

`set_velocity_ned` and `set_velocity_body` doesn't work as outlined in the [px4 documentation](https://docs.px4.io/master/en/flight_modes/offboard.html#fixed-wing). This PR adds some information regarding this into the `offboard` plugin.