### PR TITLE
#1207 extra fields for fixedwing metrics

### DIFF
--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -602,7 +602,7 @@ message FixedwingMetrics {
     float throttle_percentage = 2 [(mavsdk.options.default_value)="NaN"]; // Current throttle setting (0 to 100)
     float climb_rate_m_s = 3 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
     float groundspeed_m_s = 4 [(mavsdk.options.default_value)="NaN"]; // Current indicated groundspeed in metres per second
-    float alt_m = 5 [(mavsdk.options.default_value)="NaN"]; // Current altitude (MSL) in metres
+    float altitude_m = 5 [(mavsdk.options.default_value)="NaN"]; // Current altitude (MSL) in metres
     float heading_deg = 6 [(mavsdk.options.default_value)="NaN"]; // Current heading in compass units (0-360, 0=north)
 }
 

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -603,7 +603,7 @@ message FixedwingMetrics {
     float climb_rate_m_s = 3 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
     float groundspeed_m_s = 4 [(mavsdk.options.default_value)="NaN"]; // Current indicated groundspeed in metres per second
     float alt_m = 5 [(mavsdk.options.default_value)="NaN"]; // Current altitude (MSL) in metres
-    uint32 heading_deg = 6 [(mavsdk.options.default_value)="NaN"]; // Current heading in compass units (0-360, 0=north)
+    float heading_deg = 6 [(mavsdk.options.default_value)="NaN"]; // Current heading in compass units (0-360, 0=north)
 }
 
 // AccelerationFrd message type.


### PR DESCRIPTION
There are three extra fields in fixed wing metrics that are not returned.

- ground speed
- altitude
- heading