### PR TITLE
calibration: cancelling can fail

### DIFF
--- a/protos/calibration/calibration.proto
+++ b/protos/calibration/calibration.proto
@@ -69,7 +69,9 @@ message CalibrateGimbalAccelerometerResponse {
 }
 
 message CancelRequest {}
-message CancelResponse {}
+message CancelResponse {
+    CalibrationResult calibration_result = 1;
+}
 
 // Result type.
 message CalibrationResult {


### PR DESCRIPTION
And this should make it more consistent with other request/responses.