### PR TITLE
Result name needs to correspond to the result type

### DIFF
--- a/protos/tracking_server/tracking_server.proto
+++ b/protos/tracking_server/tracking_server.proto
@@ -61,21 +61,21 @@ message RespondTrackingPointCommandRequest {
     CommandAnswer command_answer = 1; // The ack to answer to the incoming command
 }
 message RespondTrackingPointCommandResponse {
-    TrackingServerResult result = 1; // The result of sending the response.
+    TrackingServerResult tracking_server_result = 1; // The result of sending the response.
 }
 
 message RespondTrackingRectangleCommandRequest {
     CommandAnswer command_answer = 1; // The ack to answer to the incoming command
 }
 message RespondTrackingRectangleCommandResponse {
-    TrackingServerResult result = 1; // The result of sending the response.
+    TrackingServerResult tracking_server_result = 1; // The result of sending the response.
 }
 
 message RespondTrackingOffCommandRequest {
     CommandAnswer command_answer = 1; // The ack to answer to the incoming command
 }
 message RespondTrackingOffCommandResponse {
-    TrackingServerResult result = 1; // The result of sending the response.
+    TrackingServerResult tracking_server_result = 1; // The result of sending the response.
 }
 
 // Point description type


### PR DESCRIPTION
That's needed at least for Java :sweat_smile: 