### PR TITLE
Added horizontal FOV and videostream light spectrum enum

### DIFF
--- a/protos/camera/camera.proto
+++ b/protos/camera/camera.proto
@@ -296,8 +296,8 @@ message VideoStreamSettings {
     uint32 vertical_resolution_pix = 3; // Vertical resolution (in pixels)
     uint32 bit_rate_b_s = 4; // Bit rate (in bits per second)
     uint32 rotation_deg = 5; // Video image rotation (clockwise, 0-359 degrees)
-    float horizontal_fov_deg = 7; // Horizontal fov in degrees
     string uri = 6; // Video stream URI
+    float horizontal_fov_deg = 7; // Horizontal fov in degrees
 }
 
 // Information about the video stream.

--- a/protos/camera/camera.proto
+++ b/protos/camera/camera.proto
@@ -303,21 +303,21 @@ message VideoStreamSettings {
 // Information about the video stream.
 message VideoStreamInfo {
     // Video stream status type.
-    enum Status {
-        STATUS_NOT_RUNNING = 0; // Video stream is not running
-        STATUS_IN_PROGRESS = 1; // Video stream is running
+    enum VideoStreamStatus {
+        VIDEO_STREAM_STATUS_NOT_RUNNING = 0; // Video stream is not running
+        VIDEO_STREAM_STATUS_IN_PROGRESS = 1; // Video stream is running
     }
 
     // Video stream light spectrum type
-    enum Spectrum {
-        SPECTRUM_UNKNOWN = 0; // Unknown
-        SPECTRUM_VISIBLE_LIGHT = 1; // Visible light
-        SPECTRUM_INFRARED = 2; // Infrared
+    enum VideoStreamSpectrum {
+        VIDEO_STREAM_SPECTRUM_UNKNOWN = 0; // Unknown
+        VIDEO_STREAM_SPECTRUM_VISIBLE_LIGHT = 1; // Visible light
+        VIDEO_STREAM_SPECTRUM_INFRARED = 2; // Infrared
     }
 
     VideoStreamSettings settings = 1; // Video stream settings
-    Status status = 2; // Current status of video streaming
-    Spectrum spectrum = 3; // Light-spectrum of the video stream
+    VideoStreamStatus status = 2; // Current status of video streaming
+    VideoStreamSpectrum spectrum = 3; // Light-spectrum of the video stream
 }
 
 // Information about the camera status.

--- a/protos/camera/camera.proto
+++ b/protos/camera/camera.proto
@@ -296,6 +296,7 @@ message VideoStreamSettings {
     uint32 vertical_resolution_pix = 3; // Vertical resolution (in pixels)
     uint32 bit_rate_b_s = 4; // Bit rate (in bits per second)
     uint32 rotation_deg = 5; // Video image rotation (clockwise, 0-359 degrees)
+    float horizontal_fov_deg = 7; // Horizontal fov in degrees
     string uri = 6; // Video stream URI
 }
 
@@ -307,8 +308,16 @@ message VideoStreamInfo {
         STATUS_IN_PROGRESS = 1; // Video stream is running
     }
 
+    // Video stream light spectrum type
+    enum Spectrum {
+        SPECTRUM_UNKNOWN = 0; // Unknown
+        SPECTRUM_VISIBLE_LIGHT = 1; // Visible light
+        SPECTRUM_INFRARED = 2; // Infrared
+    }
+
     VideoStreamSettings settings = 1; // Video stream settings
     Status status = 2; // Current status of video streaming
+    Spectrum spectrum = 3; // Light-spectrum of the video stream
 }
 
 // Information about the camera status.


### PR DESCRIPTION
[outdated:]
This PR adds the interfaces to subscribe to VIDEO_STREAM_STATUS messages from the camera. https://mavlink.io/en/messages/common.html#VIDEO_STREAM_STATUS 

[new]
after discussions, we decided to not duplicate the redundant mavlink messages VIDEO_STREAM_STATUS and VIDEO_STREAM_INFORMATION. Instead, we extend the current structure, and update it whenever data from either of these messages arrives. 
PR in mavsdk will follow. 
@julianoes , @JonasVautherin  can you take a look?