### PR TITLE
pb_plugins: fix requirements version

### DIFF
--- a/pb_plugins/requirements.txt
+++ b/pb_plugins/requirements.txt
@@ -1,2 +1,2 @@
-protobuf
-jinja2
+protobuf>=3.13
+jinja2>=2.11


### PR DESCRIPTION
Otherwise we can end up with protobuf with a too old version.