### PR TITLE
Only create the dictionary when it does not exist

### DIFF
--- a/pb_plugins/protoc_gen_mavsdk/docs.py
+++ b/pb_plugins/protoc_gen_mavsdk/docs.py
@@ -52,7 +52,9 @@ class Docs():
                         nested_enum_id = path[3]
 
                         if len(path) == 4:  # Top-level location of this nested enum
-                            docs['structs'][struct_id]['enums'] = []
+                            if 'enums' not in docs['structs'][struct_id]:
+                                docs['structs'][struct_id]['enums'] = []
+
                             docs['structs'][struct_id]['enums'].append(
                                 {'description': location.leading_comments, 'params': []})
                         # A value of this nested message


### PR DESCRIPTION
When parsing the docs, the script is creating its own struct to keep the documentation. When it finds a new nested enum, it creates a new dictionary to save its values. Until now, we never had more than two nested enums together, so the script worked, but the second nested enum actually erases the first one and the code crashes.

FYI @markusachtelik