### PR TITLE
Bump to 1.0.1 and add deploy CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,16 @@ jobs:
       - name: Create wheel
         working-directory: ./pb_plugins
         run: python setup.py bdist_wheel
+      - name: Upload as CI artefact
+        uses: actions/upload-artifact@v2
+        with:
+          name: protoc-gen-mavsdk.whl
+          path: ./pb_plugins/dist/*.whl
+          retention-days: 2
       - name: Deploy to PyPi
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
           TWINE_NON_INTERACTIVE: 1
         if: startsWith(github.ref, 'refs/tags/')
-        run: twine upload dist/*.whl
+        run: twine upload ./pb_plugins/dist/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - 'main'
+    tags:
+    - '*'
   pull_request:
     branches:
       - '*'
@@ -14,7 +16,23 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-        with:
-          submodules: recursive
       - name: Run prototool
         run: docker run -v "$(pwd):/work" uber/prototool:1.9.0 prototool lint protos
+
+  deploy:
+    name: deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install prerequisites
+        run: pip install --user auditwheel twine
+      - name: Create wheel
+        working-directory: ./pb_plugins
+        run: python setup.py bdist_wheel
+      - name: Deploy to PyPi
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_NON_INTERACTIVE: 1
+        if: startsWith(github.ref, 'refs/tags/')
+        run: twine upload dist/*.whl

--- a/pb_plugins/setup.py
+++ b/pb_plugins/setup.py
@@ -28,11 +28,11 @@ def parse_requirements(filename):
 
 setup(
     name="protoc-gen-mavsdk",
-    version="1.0.0",
+    version="1.0.1",
     description="Protoc plugin used to generate MAVSDK bindings",
     url="https://github.com/mavlink/MAVSDK-Proto",
     maintainer="Jonas Vautherin, Julian Oes",
-    maintainer_email="jonas@auterion.com, julian.oes@auterion.com",
+    maintainer_email="jonas.vautherin@gmail.com, julian.oes@auterion.com",
 
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Note: setup.py does not get the version from the tag, it will just push whatever is there. So we need to make sure it's correct before we tag it. An improvement could be to have setup.py take the version number as an optional argument, and have the CI pass it when building a tag.