### PR TITLE
Move QGC import from mission to mission_raw

### DIFF
--- a/protos/mission/mission.proto
+++ b/protos/mission/mission.proto
@@ -82,13 +82,6 @@ service MissionService {
      * the mission may have to be uploaded again.
      */
     rpc SetReturnToLaunchAfterMission(SetReturnToLaunchAfterMissionRequest) returns(SetReturnToLaunchAfterMissionResponse) { option (mavsdk.options.async_type) = SYNC; }
-    /*
-     * Import a QGroundControl (QGC) mission plan.
-     *
-     * The method will fail if any of the imported mission items are not supported
-     * by the MAVSDK API.
-     */
-    rpc ImportQgroundcontrolMission(ImportQgroundcontrolMissionRequest) returns(ImportQgroundcontrolMissionResponse) {}
 }
 
 message UploadMissionRequest {
@@ -160,14 +153,6 @@ message SetReturnToLaunchAfterMissionResponse {
     MissionResult mission_result = 1;
 }
 
-message ImportQgroundcontrolMissionRequest {
-    string qgc_plan_path = 1; // File path of the QGC plan
-}
-message ImportQgroundcontrolMissionResponse {
-    MissionResult mission_result = 1;
-    MissionPlan mission_plan = 2; // The mission plan
-}
-
 /*
  * Type representing a mission item.
  *
@@ -223,8 +208,6 @@ message MissionResult {
         RESULT_INVALID_ARGUMENT = 6; // Invalid argument
         RESULT_UNSUPPORTED = 7; // Mission downloaded from the system is not supported
         RESULT_NO_MISSION_AVAILABLE = 8; // No mission available on the system
-        RESULT_FAILED_TO_OPEN_QGC_PLAN = 9; // Failed to open the QGroundControl plan
-        RESULT_FAILED_TO_PARSE_QGC_PLAN = 10; // Failed to parse the QGroundControl plan
         RESULT_UNSUPPORTED_MISSION_CMD = 11; // Unsupported mission command
         RESULT_TRANSFER_CANCELLED = 12; // Mission transfer (upload or download) has been cancelled
     }

--- a/protos/mission_raw/mission_raw.proto
+++ b/protos/mission_raw/mission_raw.proto
@@ -67,6 +67,16 @@ service MissionRawService {
      * @param callback Callback to notify about change.
      */
     rpc SubscribeMissionChanged(SubscribeMissionChangedRequest) returns(stream MissionChangedResponse) { option (mavsdk.options.async_type) = ASYNC; }
+    /*
+     * Import a QGroundControl missions in JSON .plan format.
+     *
+     * Supported:
+     * - Waypoints
+     * - Survey
+     * Not supported:
+     * - Structure Scan
+     */
+    rpc ImportQgroundcontrolMission(ImportQgroundcontrolMissionRequest) returns(ImportQgroundcontrolMissionResponse) { option (mavsdk.options.async_type) = SYNC; }
 }
 
 message UploadMissionRequest {
@@ -124,6 +134,14 @@ message MissionChangedResponse {
     bool mission_changed = 1; // Mission has changed
 }
 
+message ImportQgroundcontrolMissionRequest {
+    string qgc_plan_path = 1; // File path of the QGC plan
+}
+message ImportQgroundcontrolMissionResponse {
+    MissionRawResult mission_raw_result = 1;
+    MissionImportData mission_import_data = 2; // The imported mission data
+}
+
 // Mission progress type.
 message MissionProgress {
     int32 current = 1; // Current mission item index (0-based)
@@ -147,6 +165,13 @@ message MissionItem {
     uint32 mission_type = 13; // Mission type (actually uint8_t)
 }
 
+// Mission import data
+message MissionImportData {
+    repeated MissionItem mission_items = 1; // Mission items
+    repeated MissionItem geofence_items = 2; // Geofence items
+    repeated MissionItem rally_items = 3; // Rally items
+}
+
 // Result type.
 message MissionRawResult {
     // Possible results returned for action requests.
@@ -161,6 +186,8 @@ message MissionRawResult {
         RESULT_UNSUPPORTED = 7; // Mission downloaded from the system is not supported
         RESULT_NO_MISSION_AVAILABLE = 8; // No mission available on the system
         RESULT_TRANSFER_CANCELLED = 9; // Mission transfer (upload or download) has been cancelled
+        RESULT_FAILED_TO_OPEN_QGC_PLAN = 10; // Failed to open the QGroundControl plan
+        RESULT_FAILED_TO_PARSE_QGC_PLAN = 11; // Failed to parse the QGroundControl plan
     }
 
     Result result = 1; // Result enum value


### PR DESCRIPTION
This moves the method to import QGroundControl .plan JSON mission files from the mission plugin to the mission_raw plugin.

The reasoning is as follows:
The imported missions did not really fit the Mission API, and I guess that the mission progress was often wrong.  When the missions were imported into mission, many items/commands were unsupported and dropped with a warning. Such a warning is not visible in the language wrappers and could lead to surprises. The documentation said that the method would fail if any unsupported item was being imported, however, that was not true anymore in code.

Therefore, in my opinion, it makes a lot more sense to implement the import in mission_raw where all/any mission items and commands can be imported. It's should be more complete, without surprises, and therefore safer to use.

And in later steps we can also add geofence and rally items to this API.