### PR TITLE
SubscribeDownloadLogFile should depend on GetEntries to avoid confusion

### DIFF
--- a/protos/log_files/log_files.proto
+++ b/protos/log_files/log_files.proto
@@ -26,7 +26,7 @@ message GetEntriesResponse {
 }
 
 message SubscribeDownloadLogFileRequest {
-    uint32 id = 1; // ID of the log file to download
+    Entry entry = 1; // Entry of the log file to download.
     string path = 2; // Path of where to download log file to.
 }
 message DownloadLogFileResponse {


### PR DESCRIPTION
MAVSDK needs to `get_entries()` before it can download log files. But it seems like users tend to hardcode the log file value and get confused with the error code. This puts a dependency on `get_entries()`, such that the code won't compile if it is not called.