### PR TITLE
Remove uuid from core, replaced by identification in info

### DIFF
--- a/protos/core/core.proto
+++ b/protos/core/core.proto
@@ -25,7 +25,6 @@ message ListRunningPluginsResponse {
 
 // Connection state type.
 message ConnectionState {
-    uint64 uuid = 1; // UUID of the vehicle
     bool is_connected = 2; // Whether the vehicle got connected or disconnected
 }
 


### PR DESCRIPTION
Is it already not being used by `mavsdk_server`, defaulting to 0. This change will remove it from the interfaces in the language bindings (no change is needed anywhere else).