### PR TITLE
protos: add RESULT_NO_SYSTEM to all plugins

### DIFF
--- a/protos/camera/camera.proto
+++ b/protos/camera/camera.proto
@@ -220,6 +220,7 @@ message CameraResult {
         RESULT_ERROR = 5; // An error has occured while executing the command
         RESULT_TIMEOUT = 6; // Command timed out
         RESULT_WRONG_ARGUMENT = 7; // Command has wrong argument(s)
+        RESULT_NO_SYSTEM = 8; // No system connected
     }
 
     Result result = 1; // Result enum value

--- a/protos/ftp/ftp.proto
+++ b/protos/ftp/ftp.proto
@@ -177,6 +177,7 @@ message FtpResult {
         RESULT_INVALID_PARAMETER = 9; // Invalid parameter
         RESULT_UNSUPPORTED = 10; // Unsupported command
         RESULT_PROTOCOL_ERROR = 11; // General protocol error
+        RESULT_NO_SYSTEM = 12; // No system connected
     }
 
     Result result = 1; // Result enum value

--- a/protos/geofence/geofence.proto
+++ b/protos/geofence/geofence.proto
@@ -53,6 +53,7 @@ message GeofenceResult {
         RESULT_BUSY = 4; // Vehicle is busy
         RESULT_TIMEOUT = 5; // Request timed out
         RESULT_INVALID_ARGUMENT = 6; // Invalid argument
+        RESULT_NO_SYSTEM = 7; // No system connected
     }
 
     Result result = 1; // Result enum value

--- a/protos/gimbal/gimbal.proto
+++ b/protos/gimbal/gimbal.proto
@@ -151,6 +151,7 @@ message GimbalResult {
         RESULT_ERROR = 2; // Error occurred sending the command
         RESULT_TIMEOUT = 3; // Command timed out
         RESULT_UNSUPPORTED = 4; // Functionality not supported
+        RESULT_NO_SYSTEM = 5; // No system connected
     }
 
     Result result = 1; // Result enum value

--- a/protos/info/info.proto
+++ b/protos/info/info.proto
@@ -93,6 +93,7 @@ message InfoResult {
         RESULT_UNKNOWN = 0; // Unknown result
         RESULT_SUCCESS = 1; // Request succeeded
         RESULT_INFORMATION_NOT_RECEIVED_YET = 2; // Information has not been received yet
+        RESULT_NO_SYSTEM = 3; // No system is connected
     }
 
     Result result = 1; // Result enum value

--- a/protos/log_files/log_files.proto
+++ b/protos/log_files/log_files.proto
@@ -59,6 +59,7 @@ message LogFilesResult {
         RESULT_TIMEOUT = 4; // A timeout happened
         RESULT_INVALID_ARGUMENT = 5; // Invalid argument
         RESULT_FILE_OPEN_FAILED = 6; // File open failed
+        RESULT_NO_SYSTEM = 7; // No system is connected
     }
 
     Result result = 1; // Result enum value

--- a/protos/mission/mission.proto
+++ b/protos/mission/mission.proto
@@ -210,6 +210,7 @@ message MissionResult {
         RESULT_NO_MISSION_AVAILABLE = 8; // No mission available on the system
         RESULT_UNSUPPORTED_MISSION_CMD = 11; // Unsupported mission command
         RESULT_TRANSFER_CANCELLED = 12; // Mission transfer (upload or download) has been cancelled
+        RESULT_NO_SYSTEM = 13; // No system connected
     }
 
     Result result = 1; // Result enum value

--- a/protos/mission_raw/mission_raw.proto
+++ b/protos/mission_raw/mission_raw.proto
@@ -188,6 +188,7 @@ message MissionRawResult {
         RESULT_TRANSFER_CANCELLED = 9; // Mission transfer (upload or download) has been cancelled
         RESULT_FAILED_TO_OPEN_QGC_PLAN = 10; // Failed to open the QGroundControl plan
         RESULT_FAILED_TO_PARSE_QGC_PLAN = 11; // Failed to parse the QGroundControl plan
+        RESULT_NO_SYSTEM = 12; // No system connected
     }
 
     Result result = 1; // Result enum value

--- a/protos/param/param.proto
+++ b/protos/param/param.proto
@@ -112,6 +112,7 @@ message ParamResult {
         RESULT_CONNECTION_ERROR = 3; // Connection error
         RESULT_WRONG_TYPE = 4; // Wrong type
         RESULT_PARAM_NAME_TOO_LONG = 5; // Parameter name too long (> 16)
+        RESULT_NO_SYSTEM = 6; // No system connected
     }
 
     Result result = 1; // Result enum value

--- a/protos/tune/tune.proto
+++ b/protos/tune/tune.proto
@@ -57,6 +57,7 @@ message TuneResult {
     RESULT_INVALID_TEMPO = 2; // Invalid tempo (range: 32 - 255)
     RESULT_TUNE_TOO_LONG = 3; // Invalid tune: encoded string must be at most 247 chars
     RESULT_ERROR = 4; // Failed to send the request
+    RESULT_NO_SYSTEM = 5; // No system connected
   }
 
   Result result = 1; // Result enum value


### PR DESCRIPTION
This adds the result for when no system is connected to all plugins that did not previously have that. This is required in mavsdk_server if no system is connected but we still need to answer something over gRPC.