### PR TITLE
telemetry: remove level health check

### DIFF
--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -571,7 +571,6 @@ message Health {
     bool is_gyrometer_calibration_ok = 1 [(mavsdk.options.default_value)="false"]; // True if the gyrometer is calibrated
     bool is_accelerometer_calibration_ok = 2 [(mavsdk.options.default_value)="false"]; // True if the accelerometer is calibrated
     bool is_magnetometer_calibration_ok = 3 [(mavsdk.options.default_value)="false"]; // True if the magnetometer is calibrated
-    bool is_level_calibration_ok = 4 [(mavsdk.options.default_value)="false"]; // True if the vehicle has a valid level calibration
     bool is_local_position_ok = 5 [(mavsdk.options.default_value)="false"]; // True if the local position estimate is good enough to fly in 'position control' mode
     bool is_global_position_ok = 6 [(mavsdk.options.default_value)="false"]; // True if the global position estimate is good enough to fly in 'position control' mode
     bool is_home_position_ok = 7 [(mavsdk.options.default_value)="false"]; // True if the home position has been initialized properly


### PR DESCRIPTION
We always just faked level calibration to be true/ok. Also, a level calibration is not actually required or enforced anywhere, so there is little value in checking it as a preflight check with MAVSDK.