### PR TITLE
telemetry: Added id field to Battery message.

### DIFF
--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -538,8 +538,9 @@ enum FixType {
 
 // Battery type.
 message Battery {
-    float voltage_v = 1 [(mavsdk.options.default_value)="NaN"]; // Voltage in volts
-    float remaining_percent = 2 [(mavsdk.options.default_value)="NaN"]; // Estimated battery remaining (range: 0.0 to 1.0)
+    uint32 id = 1 [(mavsdk.options.default_value)="0"]; // Battery ID, for systems with multiple batteries
+    float voltage_v = 2 [(mavsdk.options.default_value)="NaN"]; // Voltage in volts
+    float remaining_percent = 3 [(mavsdk.options.default_value)="NaN"]; // Estimated battery remaining (range: 0.0 to 1.0)
 }
 
 /*

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -538,9 +538,9 @@ enum FixType {
 
 // Battery type.
 message Battery {
-    uint32 id = 1 [(mavsdk.options.default_value)="0"]; // Battery ID, for systems with multiple batteries
-    float voltage_v = 2 [(mavsdk.options.default_value)="NaN"]; // Voltage in volts
-    float remaining_percent = 3 [(mavsdk.options.default_value)="NaN"]; // Estimated battery remaining (range: 0.0 to 1.0)
+    uint32 id = 3 [(mavsdk.options.default_value)="0"]; // Battery ID, for systems with multiple batteries
+    float voltage_v = 1 [(mavsdk.options.default_value)="NaN"]; // Voltage in volts
+    float remaining_percent = 2 [(mavsdk.options.default_value)="NaN"]; // Estimated battery remaining (range: 0.0 to 1.0)
 }
 
 /*


### PR DESCRIPTION
Added id field to Battery message.
In preparation for a PR in the MAVSDK repo that will enable handling of multiple batteries.