### PR TITLE
Add heading type to telemetry plugins

### DIFF
--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -74,6 +74,8 @@ service TelemetryService {
     rpc SubscribeDistanceSensor(SubscribeDistanceSensorRequest) returns(stream DistanceSensorResponse) {}
     // Subscribe to 'Scaled Pressure' updates.
     rpc SubscribeScaledPressure(SubscribeScaledPressureRequest) returns(stream ScaledPressureResponse) {}
+    // Subscribe to 'Heading' updates.
+    rpc SubscribeHeading(SubscribeHeadingRequest) returns(stream HeadingResponse) {}
 
     // Set rate to 'position' updates.
     rpc SetRatePosition(SetRatePositionRequest) returns(SetRatePositionResponse) {}
@@ -277,6 +279,11 @@ message ScaledPressureResponse {
     ScaledPressure scaled_pressure = 1; // The next Scaled Pressure status
 }
 
+message SubscribeHeadingRequest {}
+message HeadingResponse {
+    Heading heading_deg = 1; // The next heading (yaw) in degrees
+}
+
 message SetRatePositionRequest {
     double rate_hz = 1; // The requested rate (in Hertz)
 }
@@ -454,6 +461,11 @@ message Position {
     double longitude_deg = 2 [(mavsdk.options.default_value)="NaN"]; // Longitude in degrees (range: -180 to +180)
     float absolute_altitude_m = 3 [(mavsdk.options.default_value)="NaN"]; // Altitude AMSL (above mean sea level) in metres
     float relative_altitude_m = 4 [(mavsdk.options.default_value)="NaN"]; // Altitude relative to takeoff altitude in metres
+}
+
+// Heading type used for global position
+message Heading {
+    double heading_deg = 1 [(mavsdk.options.default_value)="NaN"]; // Heading in degrees (range: 0 to +360)
 }
 
 /*

--- a/protos/telemetry_server/telemetry_server.proto
+++ b/protos/telemetry_server/telemetry_server.proto
@@ -45,6 +45,7 @@ service TelemetryServerService {
 message PublishPositionRequest {
     Position position = 1; // The next position
     VelocityNed velocity_ned = 2; // The next velocity (NED)
+    Heading heading = 3; // Heading (yaw) in degrees
 }
 
 message PublishHomeRequest {
@@ -182,6 +183,11 @@ message Position {
     double longitude_deg = 2 [(mavsdk.options.default_value)="NaN"]; // Longitude in degrees (range: -180 to +180)
     float absolute_altitude_m = 3 [(mavsdk.options.default_value)="NaN"]; // Altitude AMSL (above mean sea level) in metres
     float relative_altitude_m = 4 [(mavsdk.options.default_value)="NaN"]; // Altitude relative to takeoff altitude in metres
+}
+
+// Heading type used for global position
+message Heading {
+    double heading_deg = 1 [(mavsdk.options.default_value)="NaN"]; // Heading in degrees (range: 0 to +360)
 }
 
 /*


### PR DESCRIPTION
Noticed we are missing heading parsing from the telemetry plugins, added a type to match