### PR TITLE
mission: add way to set up trigger distance

### DIFF
--- a/protos/mission/mission.proto
+++ b/protos/mission/mission.proto
@@ -174,6 +174,7 @@ message MissionItem {
     double camera_photo_interval_s = 10 [(mavsdk.options.default_value)="1.0"]; // Camera photo interval to use after this mission item (in seconds)
     float acceptance_radius_m = 11 [(mavsdk.options.default_value)="NaN"]; // Radius for completing a mission item (in metres)
     float yaw_deg = 12 [(mavsdk.options.default_value)="NaN"]; // Absolute yaw angle (in degrees)
+    float camera_photo_distance_m = 13 [(mavsdk.options.default_value)="NAN"]; // Camera photo distance to use after this mission item (in meters)
 
     // Possible camera actions at a mission item.
     enum CameraAction {


### PR DESCRIPTION
This enables to set the trigger distance as part of the mission.