### PR TITLE
Camera trigger server

### DIFF
--- a/protos/camera_trigger_server/camera_trigger_server.proto
+++ b/protos/camera_trigger_server/camera_trigger_server.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package mavsdk.rpc.camera_trigger_server;
+
+import "mavsdk_options.proto";
+
+option java_package = "io.mavsdk.camera_trigger_server";
+option java_outer_classname = "CameraTriggerServerProto";
+
+// Provides handling of camera trigger commands.
+service CameraTriggerServerService {
+    // Subscribe to single-capture MAV_CMD_IMAGE_START_CAPTURE commands
+    rpc SubscribeCapture(SubscribeCaptureRequest) returns(stream CaptureResponse) { option (mavsdk.options.async_type) = ASYNC; }
+}
+
+message SubscribeCaptureRequest {
+}
+
+message CaptureResponse {
+    CameraTriggerServerResult camera_trigger_server_result = 1;
+    uint32 sequence_number = 2;
+}
+
+// Result type.
+message CameraTriggerServerResult {
+    // Possible results returned for action requests.
+    enum Result {
+        RESULT_UNKNOWN = 0; // Unknown result
+        RESULT_SUCCESS = 1; // Success: the telemetry command was accepted by the vehicle
+        RESULT_NO_SYSTEM = 2; // No system connected
+        RESULT_CONNECTION_ERROR = 3; // Connection error
+        RESULT_BUSY = 4; // Vehicle is busy
+        RESULT_COMMAND_DENIED = 5; // Command refused by vehicle
+        RESULT_TIMEOUT = 6; // Request timed out
+        RESULT_UNSUPPORTED = 7; // Request not supported
+    }
+
+    Result result = 1; // Result enum value
+    string result_str = 2; // Human-readable English string describing the result
+}


### PR DESCRIPTION
This adds a new plugin for implementing subscribing to single-image `MAV_CMD_IMAGE_START_CAPTURE` commands. This is specifically intended to be used when *Trigger interface* is set to *MAVLink (forward via MAV_CMD_IMAGE_START_CAPTURE)* in the Camera Setup in QGroundControl.