### PR TITLE
protoc_gen_mavsdk: error on missing return value

### DIFF
--- a/pb_plugins/protoc_gen_mavsdk/methods.py
+++ b/pb_plugins/protoc_gen_mavsdk/methods.py
@@ -66,7 +66,7 @@ class Method(object):
         if len(return_params) > 1:
             raise Exception(
                 "Responses cannot have more than 1 return parameter" +
-                f"(and an optional '*Result')!\nError in {method_output}")
+                f" (and an optional '*Result')!\nError in {method_output}")
 
         if len(return_params) == 1:
             self._return_type = type_info_factory.create(
@@ -76,8 +76,8 @@ class Method(object):
             self._return_description = return_params[0]['docs']
         elif len(return_params) == 0 and self.return_type_required:
             raise Exception(
-                "Responses must have 1 return parameter" +
-                f"(and an optional '*Result')!\nError in {method_output}")
+                "This response must have 1 return parameter" +
+                f" (and an optional '*Result')!\nError in {method_output}")
 
     def extract_async_type(self, pb_method):
         self._is_sync = True

--- a/pb_plugins/protoc_gen_mavsdk/methods.py
+++ b/pb_plugins/protoc_gen_mavsdk/methods.py
@@ -74,6 +74,10 @@ class Method(object):
             self._return_name = name_parser_factory.create(
                 return_params[0]['field'].json_name)
             self._return_description = return_params[0]['docs']
+        elif len(return_params) == 0 and self.return_type_required:
+            raise Exception(
+                "Responses must have 1 return parameter" +
+                f"(and an optional '*Result')!\nError in {method_output}")
 
     def extract_async_type(self, pb_method):
         self._is_sync = True
@@ -118,6 +122,10 @@ class Method(object):
     @property
     def name(self):
         return self._name
+
+    @property
+    def return_type_required(self):
+        return False
 
     @staticmethod
     def collect_methods(
@@ -269,6 +277,10 @@ class Stream(Method):
         self._name = name_parser_factory.create(
             remove_subscribe(pb_method.name))
         self._template = template_env.get_template("stream.j2")
+
+    @property
+    def return_type_required(self):
+        return True
 
     def __repr__(self):
         return self._template.render(


### PR DESCRIPTION
When defining a rpc function with a return stream, it is necessary that
this function returns something that is not a *Result. So the Response
proto must contain more than just the result entry. Here we give an
explicit error message, so that the developer knows precisely what is
missing.