### PR TITLE
calibration: add unsupported result

### DIFF
--- a/protos/calibration/calibration.proto
+++ b/protos/calibration/calibration.proto
@@ -88,6 +88,7 @@ message CalibrationResult {
         RESULT_TIMEOUT = 8; // Command timed out
         RESULT_CANCELLED = 9; // Calibration process was cancelled
         RESULT_FAILED_ARMED = 10; // Calibration process failed since the vehicle is armed
+        RESULT_UNSUPPORTED =  11; // Functionality not supported
     }
 
     Result result = 1; // Result enum value


### PR DESCRIPTION
This is handy to signal if something is not expected to work for a flight stack.