### PR TITLE
Various improvements

### DIFF
--- a/pb_plugins/protoc_gen_mavsdk/autogen_file.py
+++ b/pb_plugins/protoc_gen_mavsdk/autogen_file.py
@@ -10,6 +10,7 @@ class File(object):
             plugin_name,
             package,
             template_env,
+            template_file,
             docs,
             enums,
             structs,
@@ -18,13 +19,17 @@ class File(object):
             is_server):
         self._package = name_parser_factory.create(package)
         self._plugin_name = name_parser_factory.create(plugin_name)
-        self._template = template_env.get_template("file.j2")
         self._class_description = docs['class'].strip()
         self._enums = enums
         self._structs = structs
         self._methods = methods
         self._has_result = has_result
         self._is_server = is_server
+
+        if template_file is None:
+            self._template = template_env.get_template("file.j2")
+        else:
+            self._template = template_env.get_template(template_file)
 
     def __repr__(self):
         return self._template.render(package=self._package,

--- a/pb_plugins/protoc_gen_mavsdk/enum.py
+++ b/pb_plugins/protoc_gen_mavsdk/enum.py
@@ -15,7 +15,10 @@ class Enum(object):
             parent_struct=None):
         self._plugin_name = name_parser_factory.create(plugin_name)
         self._package = name_parser_factory.create(package)
-        self._template = template_env.get_template("enum.j2")
+        try:
+            self._template = template_env.get_template("enum.j2")
+        except:
+            self._template = None
         self._enum_description = enum_docs['description'].strip(
         ) if enum_docs else None
         self._name = name_parser_factory.create(pb_enum.name)

--- a/pb_plugins/protoc_gen_mavsdk/enum.py
+++ b/pb_plugins/protoc_gen_mavsdk/enum.py
@@ -41,6 +41,18 @@ class Enum(object):
             self._values.append({'name': value_name, 'description': enum_docs['params'][value_id], 'has_prefix': has_prefix})
             value_id += 1
 
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def values(self):
+        return self._values
+
+    @property
+    def parent_struct(self):
+        return self._parent_struct
+
     def __repr__(self):
         return self._template.render(plugin_name=self._plugin_name,
                                      package=self._package,

--- a/pb_plugins/protoc_gen_mavsdk/methods.py
+++ b/pb_plugins/protoc_gen_mavsdk/methods.py
@@ -214,7 +214,10 @@ class Call(Method):
             pb_method,
             requests,
             responses)
-        self._template = template_env.get_template("call.j2")
+        try:
+            self._template = template_env.get_template("call.j2")
+        except:
+            self._template = None
         self._no_return = True
 
     def __repr__(self):
@@ -250,7 +253,10 @@ class Request(Method):
             pb_method,
             requests,
             responses)
-        self._template = template_env.get_template("request.j2")
+        try:
+            self._template = template_env.get_template("request.j2")
+        except:
+            self._template = None
         self._method_description = method_description
         self._returns = True
 
@@ -294,7 +300,10 @@ class Stream(Method):
         self._is_stream = True
         self._name = name_parser_factory.create(
             remove_subscribe(pb_method.name))
-        self._template = template_env.get_template("stream.j2")
+        try:
+            self._template = template_env.get_template("stream.j2")
+        except:
+            self._template = None
 
     @property
     def return_type_required(self):

--- a/pb_plugins/protoc_gen_mavsdk/methods.py
+++ b/pb_plugins/protoc_gen_mavsdk/methods.py
@@ -20,7 +20,6 @@ class Method(object):
             pb_method,
             requests,
             responses):
-        self._is_stream = False
         self._no_return = False
         self._has_result = False
         self._returns = False
@@ -102,10 +101,6 @@ class Method(object):
                 self._is_finite = pb_method.options.Extensions[method_descriptor]
 
     @property
-    def is_stream(self):
-        return self._is_stream
-
-    @property
     def no_return(self):
         return self._no_return
 
@@ -130,8 +125,16 @@ class Method(object):
         return self._name
 
     @property
+    def params(self):
+        return self._params
+
+    @property
     def return_type_required(self):
         return False
+
+    @property
+    def method_description(self):
+        return self._method_description
 
     @staticmethod
     def collect_methods(
@@ -220,6 +223,10 @@ class Call(Method):
             self._template = None
         self._no_return = True
 
+    @property
+    def is_call(self):
+        return True
+
     def __repr__(self):
         return self._template.render(name=self._name,
                                      params=self._params,
@@ -260,6 +267,22 @@ class Request(Method):
         self._method_description = method_description
         self._returns = True
 
+    @property
+    def is_request(self):
+        return True
+
+    @property
+    def return_name(self):
+        return self._return_name
+
+    @property
+    def return_type(self):
+        return self._return_type
+
+    @property
+    def return_description(self):
+        return self._return_description
+
     def __repr__(self):
         return self._template.render(
             name=self._name,
@@ -297,7 +320,6 @@ class Stream(Method):
             pb_method,
             requests,
             responses)
-        self._is_stream = True
         self._name = name_parser_factory.create(
             remove_subscribe(pb_method.name))
         try:
@@ -308,6 +330,22 @@ class Stream(Method):
     @property
     def return_type_required(self):
         return True
+
+    @property
+    def is_stream(self):
+        return True
+
+    @property
+    def return_name(self):
+        return self._return_name
+
+    @property
+    def return_type(self):
+        return self._return_type
+
+    @property
+    def return_description(self):
+        return self._return_description
 
     def __repr__(self):
         return self._template.render(

--- a/pb_plugins/protoc_gen_mavsdk/name_parser.py
+++ b/pb_plugins/protoc_gen_mavsdk/name_parser.py
@@ -9,15 +9,14 @@ class NameParserFactory:
     def create(self, name):
         return NameParser(name, self._initialisms)
 
-    def set_template_path(self, template_path):
-        self._initialisms = self._load_initialisms(template_path)
+    def set_initialisms_path(self, initialisms_path):
+        self._initialisms = self._load_initialisms(initialisms_path)
 
-    def _load_initialisms(self, template_path):
+    def _load_initialisms(self, initialisms_path):
         try:
-            _initialisms_path = f"{template_path}/initialisms"
-            with open(_initialisms_path, "r") as handle:
+            with open(initialisms_path, "r") as handle:
                 return json.loads(handle.read())
-        except FileNotFoundError:
+        except:
             return []
 
 

--- a/pb_plugins/protoc_gen_mavsdk/struct.py
+++ b/pb_plugins/protoc_gen_mavsdk/struct.py
@@ -18,7 +18,10 @@ class Struct(object):
                  template_env, pb_struct, struct_docs):
         self._plugin_name = name_parser_factory.create(plugin_name)
         self._package = name_parser_factory.create(package)
-        self._template = template_env.get_template("struct.j2")
+        try:
+            self._template = template_env.get_template("struct.j2")
+        except:
+            self._template = None
         self._struct_description = struct_docs['description'].strip(
         ) if struct_docs else None
         self._name = name_parser_factory.create(pb_struct.name)

--- a/pb_plugins/protoc_gen_mavsdk/struct.py
+++ b/pb_plugins/protoc_gen_mavsdk/struct.py
@@ -72,6 +72,22 @@ class Struct(object):
     def name(self):
         return self._name
 
+    @property
+    def fields(self):
+        return self._fields
+
+    @property
+    def nested_enums(self):
+        return self._nested_enums
+
+    @property
+    def nested_structs(self):
+        return self._nested_structs
+
+    @property
+    def struct_description(self):
+        return self._struct_description
+
     @staticmethod
     def collect_structs(plugin_name, package, structs, template_env, docs):
         _structs = {}

--- a/pb_plugins/protoc_gen_mavsdk/type_info.py
+++ b/pb_plugins/protoc_gen_mavsdk/type_info.py
@@ -7,15 +7,14 @@ class TypeInfoFactory:
     def create(self, field):
         return TypeInfo(field, self._conversion_dict)
 
-    def set_template_path(self, template_path):
-        self._conversion_dict = self._load_conversions_dict(template_path)
+    def set_conversion_path(self, conversions_path):
+        self._conversion_dict = self._load_conversions_dict(conversions_path)
 
-    def _load_conversions_dict(self, template_path):
+    def _load_conversions_dict(self, conversions_path):
         try:
-            _conversion_dict_path = f"{template_path}/type_conversions"
-            with open(_conversion_dict_path, "r") as handle:
+            with open(conversions_path, "r") as handle:
                 return json.loads(handle.read())
-        except FileNotFoundError:
+        except:
             return {}
 
 

--- a/pb_plugins/protoc_gen_mavsdk/utils.py
+++ b/pb_plugins/protoc_gen_mavsdk/utils.py
@@ -96,10 +96,10 @@ def jinja_indent(_in_str, level):
     )
 
 
-def get_template_env(_searchpath):
+def get_template_env(_searchpath, _lstrip_blocks, _trim_blocks):
     """ Generates the template environment """
     _template_env = Environment(loader=FileSystemLoader(
-        searchpath=_searchpath))
+        searchpath=_searchpath), lstrip_blocks=_lstrip_blocks, trim_blocks=_trim_blocks)
 
     # Register some functions we need to access in the template
     _template_env.globals.update(indent=jinja_indent)

--- a/pb_plugins/setup.py
+++ b/pb_plugins/setup.py
@@ -28,7 +28,7 @@ def parse_requirements(filename):
 
 setup(
     name="protoc-gen-mavsdk",
-    version="1.0.3",
+    version="1.1.0",
     description="Protoc plugin used to generate MAVSDK bindings",
     url="https://github.com/mavlink/MAVSDK-Proto",
     maintainer="Jonas Vautherin, Julian Oes",


### PR DESCRIPTION
* Make sub-template files (e.g. enum.j2, struct.j2, ...) optional
* Expose everything to root template (enabling single-template definitions)
* Add more command arguments, giving more control about e.g. the output file or the root template file.

Tested in MAVSDK and MAVSDK-Python: generating the code with this version does not change anything :+1:.

Those changes are used in https://github.com/JonasVautherin/protoc-gen-mavsdk-example.