### PR TITLE
param: allow to set component ID and protocol

### DIFF
--- a/protos/param/param.proto
+++ b/protos/param/param.proto
@@ -172,6 +172,7 @@ message ParamResult {
         RESULT_PARAM_NAME_TOO_LONG = 5; // Parameter name too long (> 16)
         RESULT_NO_SYSTEM = 6; // No system connected
         RESULT_PARAM_VALUE_TOO_LONG = 7; // Param value too long (> 128)
+        RESULT_FAILED = 8; // Operation failed.
     }
 
     Result result = 1; // Result enum value

--- a/protos/param/param.proto
+++ b/protos/param/param.proto
@@ -49,6 +49,12 @@ service ParamService {
      * Get all parameters.
      */
     rpc GetAllParams(GetAllParamsRequest) returns(GetAllParamsResponse) { option (mavsdk.options.async_type) = SYNC; }
+    /*
+     * Select component ID of parameter component to talk to and param protocol version.
+     *
+     * Default is the autopilot component (1), and Version (0).
+     */
+    rpc SelectComponent(SelectComponentRequest) returns(SelectComponentResponse) { option (mavsdk.options.async_type) = SYNC; }
 }
 
 message GetParamIntRequest {
@@ -104,6 +110,21 @@ message GetAllParamsRequest {}
 
 message GetAllParamsResponse {
     AllParams params = 1; // Collection of all parameters
+}
+
+message SelectComponentResponse {
+    ParamResult param_result = 1;
+}
+
+message SelectComponentRequest {
+    int32 component_id = 1; // MAVLink component Id of component to select
+    ProtocolVersion protocol_version = 2; // Protocol version
+}
+
+// Parameter version
+enum ProtocolVersion {
+    PROTOCOL_VERSION_V1 = 0; // Original v1 version
+    PROTOCOL_VERSION_EXT = 1; // Extended param version
 }
 
 /*


### PR DESCRIPTION
This should allow to create param plugins to talk to specific components.

This replaces the `param->late_init()` suggested in https://github.com/mavlink/MAVSDK/pull/1809 by @Consti10.