### PR TITLE
camera: add result when protocol is not supported

### DIFF
--- a/protos/camera/camera.proto
+++ b/protos/camera/camera.proto
@@ -244,6 +244,7 @@ message CameraResult {
         RESULT_TIMEOUT = 6; // Command timed out
         RESULT_WRONG_ARGUMENT = 7; // Command has wrong argument(s)
         RESULT_NO_SYSTEM = 8; // No system connected
+        RESULT_PROTOCOL_UNSUPPORTED = 9; // Definition file protocol not supported
     }
 
     Result result = 1; // Result enum value


### PR DESCRIPTION
This is required to support builds without CURL. So if CURL is not built in, then http URIs will just return ResultProtocolUnsupported.

Signed-off-by: Julian Oes <julian@oes.ch>