### PR TITLE
protoc-gen-mavsdk: bump version to 1.1.1

### DIFF
--- a/pb_plugins/setup.py
+++ b/pb_plugins/setup.py
@@ -28,7 +28,7 @@ def parse_requirements(filename):
 
 setup(
     name="protoc-gen-mavsdk",
-    version="1.1.0",
+    version="1.1.1",
     description="Protoc plugin used to generate MAVSDK bindings",
     url="https://github.com/mavlink/MAVSDK-Proto",
     maintainer="Jonas Vautherin, Julian Oes",


### PR DESCRIPTION
This mainly changes the max protobuf version to 3.20.1 which should fix the versioning nightmare with docs.

Signed-off-by: Julian Oes <julian@oes.ch>