### PR TITLE
Add PublishDistanceSensor to Telemetry Server

### DIFF
--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -739,9 +739,6 @@ message Odometry {
 
 // DistanceSensor message type.
 message DistanceSensor {
-    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
-    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
-    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
     float minimum_distance_cm = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
     float maximum_distance_cm = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
     float current_distance_cm = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -739,9 +739,12 @@ message Odometry {
 
 // DistanceSensor message type.
 message DistanceSensor {
-    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
-    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
-    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.
+    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
+    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
+    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
+    float minimum_distance_cm = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
+    float maximum_distance_cm = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
+    float current_distance_cm = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.
 }
 
 // Scaled Pressure message type.

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -739,6 +739,9 @@ message Odometry {
 
 // DistanceSensor message type.
 message DistanceSensor {
+    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
+    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
+    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
     float minimum_distance_cm = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
     float maximum_distance_cm = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
     float current_distance_cm = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -739,12 +739,9 @@ message Odometry {
 
 // DistanceSensor message type.
 message DistanceSensor {
-    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
-    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
-    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
-    float minimum_distance_cm = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
-    float maximum_distance_cm = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
-    float current_distance_cm = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.
+    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
+    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
+    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.
 }
 
 // Scaled Pressure message type.

--- a/protos/telemetry_server/telemetry_server.proto
+++ b/protos/telemetry_server/telemetry_server.proto
@@ -40,6 +40,8 @@ service TelemetryServerService {
     rpc PublishRawImu(PublishRawImuRequest) returns(PublishRawImuResponse) { option (mavsdk.options.async_type) = SYNC; }
     // Publish to 'unix epoch time' updates.
     rpc PublishUnixEpochTime(PublishUnixEpochTimeRequest) returns(PublishUnixEpochTimeResponse) { option (mavsdk.options.async_type) = SYNC; }
+    // Publish to "distance sensor" updates.
+    rpc PublishDistanceSensor(PublishDistanceSensorRequest) returns(PublishDistanceSensorResponse) { option (mavsdk.options.async_type) = SYNC; }
 }
 
 message PublishPositionRequest {
@@ -119,6 +121,10 @@ message PublishUnixEpochTimeRequest {
     uint64 time_us = 1; // The next 'unix epoch time' status
 }
 
+message PublishDistanceSensorRequest {
+    DistanceSensor distance_sensor = 1; // The next 'Distance Sensor' status
+}
+
 message PublishPositionResponse {
     TelemetryServerResult telemetry_server_result = 1;
 }
@@ -174,6 +180,10 @@ message PublishRawImuResponse {
 
 
 message PublishUnixEpochTimeResponse {
+    TelemetryServerResult telemetry_server_result = 1;
+}
+
+message PublishDistanceSensorResponse {
     TelemetryServerResult telemetry_server_result = 1;
 }
 

--- a/protos/telemetry_server/telemetry_server.proto
+++ b/protos/telemetry_server/telemetry_server.proto
@@ -391,6 +391,9 @@ message Odometry {
 
 // DistanceSensor message type.
 message DistanceSensor {
+    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
+    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
+    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
     float minimum_distance_cm = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
     float maximum_distance_cm = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
     float current_distance_cm = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.

--- a/protos/telemetry_server/telemetry_server.proto
+++ b/protos/telemetry_server/telemetry_server.proto
@@ -391,9 +391,12 @@ message Odometry {
 
 // DistanceSensor message type.
 message DistanceSensor {
-    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
-    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
-    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.
+    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
+    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
+    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
+    float minimum_distance_cm = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
+    float maximum_distance_cm = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
+    float current_distance_cm = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.
 }
 
 // Scaled Pressure message type.

--- a/protos/telemetry_server/telemetry_server.proto
+++ b/protos/telemetry_server/telemetry_server.proto
@@ -391,12 +391,9 @@ message Odometry {
 
 // DistanceSensor message type.
 message DistanceSensor {
-    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
-    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
-    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
-    float minimum_distance_cm = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
-    float maximum_distance_cm = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
-    float current_distance_cm = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.
+    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
+    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
+    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.
 }
 
 // Scaled Pressure message type.

--- a/protos/telemetry_server/telemetry_server.proto
+++ b/protos/telemetry_server/telemetry_server.proto
@@ -391,9 +391,6 @@ message Odometry {
 
 // DistanceSensor message type.
 message DistanceSensor {
-    float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
-    float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
-    float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // OBSOLETE: This was a typo in the naming.
     float minimum_distance_cm = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
     float maximum_distance_cm = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
     float current_distance_cm = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.


### PR DESCRIPTION
## Related PRs
- Proto: https://github.com/mavlink/MAVSDK-Proto/pull/310 **(this PR)**
- MAVSDK: https://github.com/mavlink/MAVSDK/pull/1964 

## Description
The DistanceSensor is already part of telemetry and telemetry_server. The subscriber was implemented in telemetry, but the publisher in telemetry_server is missing.

I would like to add a publisher for [DISTANCE_SENSOR](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR) to MAVSDK. 

The question is also whether we should include the full message spec while at it. The missing fields that exist in mavlink but not in the proto definition of DistanceSensor are:
- Type (MAV_DISTANCE_SENSOR)
- ID
- Orientation (MAV_SENSOR_ORIENTATION)
- Covariance
- Horizontal FOV
- Vertical FOV
- Quaternion for orientation
- Signal Quality

Does it make sense to add all of them right away, or does MAVSDK deliberately leave some fields out that exist in mavlink, because they are not used by 99% of the people?

## Question
I noticed a bug in the current implementation of the distance sensor subscriber implementation in MAVSDK. The distance fields in mavlink are specified to be centimeters, whereas the same fields in Proto are specified in meters, but there is no conversion happening. I fixed this in the MAVSDK implementation: https://github.com/mavlink/MAVSDK/pull/1964/files#diff-c6be7609c4729a6ca704109572c7b755aaac050cc429c91a024021d7760faf59R1440-R1442

Alternatively we could also change the unit in Proto to centimeters. But this would change the existing API. Changing the implementation though can just as well cause problems to someone who's already using this MAVSDK function :sweat_smile: 

Which option is better?