### PR TITLE
Add missing documentation for winch/gripper plugins

### DIFF
--- a/protos/gripper/gripper.proto
+++ b/protos/gripper/gripper.proto
@@ -5,6 +5,9 @@ package mavsdk.rpc.gripper;
 option java_package = "io.mavsdk.gripper";
 option java_outer_classname = "GripperProto";
 
+/*
+ * Allows users to send gripper actions.
+ */
 service GripperService {
     /*
      * Gripper grab cargo.
@@ -17,6 +20,12 @@ service GripperService {
     rpc Release(ReleaseRequest) returns(ReleaseResponse) {}
 }
 
+/*
+ * Gripper Actions.
+ *
+ * Available gripper actions are defined in mavlink under
+ * https://mavlink.io/en/messages/common.html#GRIPPER_ACTIONS
+ */
 enum GripperAction {
     GRIPPER_ACTION_RELEASE = 0; // Open the gripper to release the cargo
     GRIPPER_ACTION_GRAB = 1; // Close the gripper and grab onto cargo

--- a/protos/winch/winch.proto
+++ b/protos/winch/winch.proto
@@ -7,6 +7,10 @@ import "mavsdk_options.proto";
 option java_package = "io.mavsdk.winch";
 option java_outer_classname = "WinchProto";
 
+/*
+ * Allows users to send winch actions, as well as receive status information from winch systems.
+ *
+ */
 service WinchService {
     // Subscribe to 'winch status' updates.
     rpc SubscribeStatus(SubscribeStatusRequest) returns(stream StatusResponse) {}
@@ -70,6 +74,15 @@ message StatusResponse {
     Status status = 1; // The next 'winch status' state
 }
 
+/*
+ * Winch Status Flags.
+ *
+ * The status flags are defined in mavlink
+ * https://mavlink.io/en/messages/common.html#MAV_WINCH_STATUS_FLAG.
+ *
+ * Multiple status fields can be set simultaneously. Mavlink does
+ * not specify which states are mutually exclusive.
+ */
 message StatusFlags {
     bool healthy = 1;           // Winch is healthy
     bool fully_retracted = 2;   // Winch line is fully retracted
@@ -87,6 +100,7 @@ message StatusFlags {
     bool load_payload = 14;     // Winch is loading a payload
 }
 
+// Status type.
 message Status {
     uint64 time_usec = 1; // Time in usec
     float line_length_m = 2; // Length of the line in meters
@@ -98,6 +112,7 @@ message Status {
     StatusFlags status_flags = 8; // Status flags
 }
 
+// Winch Action type.
 enum WinchAction {
     WINCH_ACTION_RELAXED = 0;       // Allow motor to freewheel
     WINCH_ACTION_RELATIVE_LENGTH_CONTROL = 1; // Wind or unwind specified length of line, optionally using specified rate


### PR DESCRIPTION
Slipped through the cracks in the previous PR: https://github.com/mavlink/MAVSDK-Proto/pull/308

Addresses the following CI failure over in MAVSDK:
```
2023-01-31T13:50:06.1606188Z Preprocessing /home/runner/work/MAVSDK/MAVSDK/tools/docs/install/include/mavsdk/plug/home/runner/work/MAVSDK/MAVSDK/tools/docs/install/include/mavsdk/plugins/winch/winch.h:91: warning: Compound mavsdk::Winch::StatusFlags is not documented.
2023-01-31T13:50:06.1606831Z /home/runner/work/MAVSDK/MAVSDK/tools/docs/install/include/mavsdk/plugins/winch/winch.h:28: warning: Compound mavsdk::Winch is not documented.
2023-01-31T13:50:06.1607356Z /home/runner/work/MAVSDK/MAVSDK/tools/docs/install/include/mavsdk/plugins/gripper/gripper.h:28: warning: Compound mavsdk::Gripper is not documented.
2023-01-31T13:50:06.1607877Z /home/runner/work/MAVSDK/MAVSDK/tools/docs/install/include/mavsdk/plugins/winch/winch.h:128: warning: Compound mavsdk::Winch::Status is not documented.
2023-01-31T13:50:06.1608449Z Generating docs for /home/runner/work/MAVSDK/MAVSDK/tools/docs/install/include/mavsdk/plugins/gripper/gripper.h:64: warning: Member GripperAction (enumeration) of class mavsdk::Gripper is not documented.
2023-01-31T13:50:06.1609079Z Generating docs/home/runner/work/MAVSDK/MAVSDK/tools/docs/install/include/mavsdk/plugins/winch/winch.h:64: warning: Member WinchAction (enumeration) of class mavsdk::Winch is not documented.
```