### PR TITLE
added pos,vel,acc offboard

### DIFF
--- a/protos/offboard/offboard.proto
+++ b/protos/offboard/offboard.proto
@@ -70,6 +70,12 @@ service OffboardService {
     * Set the position in NED coordinates, with the velocity to be used as feed-forward.
     */
     rpc SetPositionVelocityNed(SetPositionVelocityNedRequest) returns(SetPositionVelocityNedResponse) { option (mavsdk.options.async_type) = SYNC; }
+
+    /*
+    * Set the position Velocity and Acceleration in NED coordinates, with the velocity and acceleration to be used as feed-forward.
+    */
+    rpc SetPositionVelocityAccelerationNed(SetPositionVelocityAccelerationNedRequest) returns(SetPositionVelocityAccelerationNedResponse) { option (mavsdk.options.async_type) = SYNC; }
+
     /*
     * Set the acceleration in NED coordinates.
     */
@@ -144,7 +150,18 @@ message SetPositionVelocityNedRequest {
     PositionNedYaw position_ned_yaw = 1; // Position and yaw
     VelocityNedYaw velocity_ned_yaw = 2; // Velocity and yaw
 }
+
+message SetPositionVelocityAccelerationNedRequest {
+    PositionNedYaw position_ned_yaw = 1; // Position and yaw
+    VelocityNedYaw velocity_ned_yaw = 2; // Velocity and yaw
+    AccelerationNed acceleration_ned = 3; // Acceleration
+}
+
 message SetPositionVelocityNedResponse {
+    OffboardResult offboard_result = 1;
+}
+
+message SetPositionVelocityAccelerationNedResponse {
     OffboardResult offboard_result = 1;
 }
 

--- a/protos/offboard/offboard.proto
+++ b/protos/offboard/offboard.proto
@@ -72,7 +72,7 @@ service OffboardService {
     rpc SetPositionVelocityNed(SetPositionVelocityNedRequest) returns(SetPositionVelocityNedResponse) { option (mavsdk.options.async_type) = SYNC; }
 
     /*
-    * Set the position Velocity and Acceleration in NED coordinates, with the velocity and acceleration to be used as feed-forward.
+    * Set the position, velocity and acceleration in NED coordinates, with velocity and acceleration used as feed-forward.
     */
     rpc SetPositionVelocityAccelerationNed(SetPositionVelocityAccelerationNedRequest) returns(SetPositionVelocityAccelerationNedResponse) { option (mavsdk.options.async_type) = SYNC; }
 


### PR DESCRIPTION
I have added option to send acceleration as well by creating a function called drone.offboard.set_position_velocity_acceleration_ned(
            PositionNedYaw(*position, yaw),
            VelocityNedYaw(*velocity, yaw),
            AccelerationNed(*acceleration)
        )
        it still has problems
        
        steps I did:
        forked mavsdk and mavsdk proto.
        edited the proto files for my new message and function
        added the  cpp functions and edit cpp and h files in mavsdk src
        


```
Offboard::Result OffboardImpl::send_position_velocity_acceleration_ned()
{
    const static uint16_t IGNORE_YAW_RATE = (1 << 11);

    std::lock_guard<std::mutex> lock(_mutex);

    mavlink_message_t message;
    mavlink_msg_set_position_target_local_ned_pack(
        _system_impl->get_own_system_id(),
        _system_impl->get_own_component_id(),
        &message,
        static_cast<uint32_t>(_system_impl->get_time().elapsed_ms()),
        _system_impl->get_system_id(),
        _system_impl->get_autopilot_id(),
        MAV_FRAME_LOCAL_NED,
        IGNORE_YAW_RATE,
        _position_ned_yaw.north_m,
        _position_ned_yaw.east_m,
        _position_ned_yaw.down_m,
        _velocity_ned_yaw.north_m_s,
        _velocity_ned_yaw.east_m_s,
        _velocity_ned_yaw.down_m_s,
        _acceleration_ned.north_m_s2,
        _acceleration_ned.east_m_s2,
        _acceleration_ned.down_m_s2,
        to_rad_from_deg(_position_ned_yaw.yaw_deg), // yaw
        0.0f); // yaw_rate
    return _system_impl->send_message(message) ? Offboard::Result::Success :
                                                 Offboard::Result::ConnectionError;
}
```

build the mavsdk
cloned the mavsdk python and with new proto used the python generator

now the function appears in python autocomplete but when I run it from the code I get below error:


-- Setting initial setpoint
-- Starting offboard
-- Performing trajectory
 Mode number: 10, Description: Initial climbing state
Traceback (most recent call last):
  File "/home/alireza/mavsdk_drone_show/offboard_from_csv.py", line 207, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/alireza/mavsdk_drone_show/offboard_from_csv.py", line 199, in main
    await asyncio.gather(*tasks)
  File "/home/alireza/mavsdk_drone_show/offboard_from_csv.py", line 153, in run
    await drone.offboard.set_position_velocity_acceleration_ned(
  File "/home/alireza/MAVSDK-Python/mavsdk/offboard.py", line 1482, in set_position_velocity_acceleration_ned
    response = await self._stub.SetPositionVelocityAccelerationNed(request)
  File "/home/alireza/.local/lib/python3.10/site-packages/aiogrpc/channel.py", line 40, in __call__
    return await fut
grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
        status = StatusCode.UNIMPLEMENTED
        details = ""
        debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2023-05-19T05:00:45.0945068+00:00", grpc_status:12, grpc_message:""}"
>
Exception ignored in: <function System.__del__ at 0x7fe5e30f4820>
Traceback (most recent call last):
  File "/home/alireza/MAVSDK-Python/mavsdk/system.py", line 86, in __del__
  File "/home/alireza/MAVSDK-Python/mavsdk/system.py", line 122, in _stop_mavsdk_server
ImportError: sys.meta_path is None, Python is likely shutting down
[05:00:45|Debug] MAVLink: info: Preflight Fail: No manual control input  (system_impl.cpp:250)





