### PR TITLE
workflows: update GitHub runner and prototool

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,11 @@ on:
 jobs:
   prototool:
     name: prototool linter
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
       - name: Run prototool
-        run: docker run -v "$(pwd):/work" uber/prototool:1.9.0 prototool lint protos
+        run: docker run -v "$(pwd):/work" uber/prototool:1.10.0 prototool lint protos
 
   deploy:
     name: deploy


### PR DESCRIPTION
It looks like the 18.04 containers didn't start no longer.