### PR TITLE
Customizing distance sensor to add orientation for multiple sensor support

### DIFF
--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -742,6 +742,7 @@ message DistanceSensor {
     float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
     float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
     float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.
+    uint32 orientation = 4  [(mavsdk.options.default_value)="0"]; // Sensor Orientation reading, 0 if unknown.
 }
 
 // Scaled Pressure message type.

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -742,7 +742,7 @@ message DistanceSensor {
     float minimum_distance_m = 1 [(mavsdk.options.default_value)="NaN"]; // Minimum distance the sensor can measure, NaN if unknown.
     float maximum_distance_m = 2 [(mavsdk.options.default_value)="NaN"]; // Maximum distance the sensor can measure, NaN if unknown.
     float current_distance_m = 3 [(mavsdk.options.default_value)="NaN"]; // Current distance reading, NaN if unknown.
-    uint32 orientation = 4  [(mavsdk.options.default_value)="0"]; // Sensor Orientation reading, 0 if unknown.
+    EulerAngle orientation = 4; // Sensor Orientation reading.
 }
 
 // Scaled Pressure message type.


### PR DESCRIPTION
Added orientation parameter to telemetry.distance_sensor to take advantage of the mavlink orientation parameter and receive measurements for multiple distance sensors 