### PR TITLE
mission_raw: add planned home position

### DIFF
--- a/protos/mission_raw/mission_raw.proto
+++ b/protos/mission_raw/mission_raw.proto
@@ -170,6 +170,8 @@ message MissionImportData {
     repeated MissionItem mission_items = 1; // Mission items
     repeated MissionItem geofence_items = 2; // Geofence items
     repeated MissionItem rally_items = 3; // Rally items
+    bool has_planned_home = 4; // Whether it contains a planned home position element or not
+    MissionItem planned_home_position = 5; // Planned home position
 }
 
 // Result type.


### PR DESCRIPTION
Goes with https://github.com/mavlink/MAVSDK/pull/2115

The thing is that now it forces everybody to set that value (we can't have it optional with the auto-generation) :thinking:. I wonder if that's reasonable or not :thinking:.

Do users even use the `MissionImportData` directly, or is it just used in the implementation somehow?

@RomanBapst: what do you think?