### PR TITLE
Revert recent camera_server additions

### DIFF
--- a/protos/camera_server/camera_server.proto
+++ b/protos/camera_server/camera_server.proto
@@ -19,12 +19,6 @@ service CameraServerService {
     
     // Respond to an image capture request from SubscribeTakePhoto.
     rpc RespondTakePhoto(RespondTakePhotoRequest) returns(RespondTakePhotoResponse) { option (mavsdk.options.async_type) = SYNC; }
-
-    // Subscribe to start video requests. Each request received should response to using StartVideoResponse
-    rpc SubscribeStartVideo(SubscribeStartVideoRequest) returns(stream StartVideoResponse) { option (mavsdk.options.async_type) = ASYNC; }
-
-    // Subscribe to stop video requests. Each request received should response to using StopVideoResponse
-    rpc SubscribeStopVideo(SubscribeStopVideoRequest) returns(stream StopVideoResponse) { option (mavsdk.options.async_type) = ASYNC; }
 }
 
 message SetInformationRequest {
@@ -44,18 +38,9 @@ message SetInProgressResponse {
 }
 
 message SubscribeTakePhotoRequest {}
+
 message TakePhotoResponse {
     int32 index = 1;
-}
-
-message SubscribeStartVideoRequest {}
-message StartVideoResponse {
-    int32 stream_id = 1;    // video stream id
-}
-
-message SubscribeStopVideoRequest {}
-message StopVideoResponse {
-    int32 stream_id = 1;    // video stream id
 }
 
 // Possible results when taking a photo.


### PR DESCRIPTION
This reverts:
"camera server : add start stop video subscribe (#318)"

We will add it back in shortly. This is just because the PR following this has not been merged.

This reverts commit 8966cf59029ac17d81654071ca6d3d27f0d8897d.

@tbago I'll bring the changes back in soon. I just need to finish the FTP stuff first.