### PR TITLE
Added arm authorization server functionality

### DIFF
--- a/protos/arm_authorizer_server/arm_authorizer_server.proto
+++ b/protos/arm_authorizer_server/arm_authorizer_server.proto
@@ -26,12 +26,12 @@ message SubscribeArmAuthorizationResponse {
 
 // Messages for RespondArmAuthorization
 message AcceptArmAuthorizationRequest {
-    int32 valid_time = 1; // Time in seconds for which this authorization is valid
+    int32 valid_time_s = 1; // Time in seconds for which this authorization is valid
 }
 
 // Result type
 message AcceptArmAuthorizationResponse {
-    CommandAnswer command_answer = 1; // Result enum value
+    ArmAutorizerServerResult arm_authorizer_server_result = 1; // Result enum value
 }
 
 // Messages for RespondArmAuthorization
@@ -43,12 +43,17 @@ message RejectArmAuthorizationRequest {
 
 // Result type
 message RejectArmAuthorizationResponse {
-    CommandAnswer command_answer = 1; // Result enum value
+    ArmAutorizerServerResult arm_authorizer_server_result = 1; // Result enum value
 }
 
-enum CommandAnswer {
-    COMMAND_ANSWER_ACCEPTED = 0; // Command accepted
-    COMMAND_ANSWER_FAILED = 1; // Command failed
+message ArmAutorizerServerResult {
+    enum Result {
+        RESULT_SUCCESS = 0; // Command accepted
+        RESULT_FAILED = 1; // Command failed
+    }
+
+    Result result = 1; // Result enum value
+    string result_str = 2; // Human-readable English string describing the result
 }
 
 enum RejectionReason {

--- a/protos/arm_authorizer_server/arm_authorizer_server.proto
+++ b/protos/arm_authorizer_server/arm_authorizer_server.proto
@@ -57,10 +57,10 @@ message ArmAutorizerServerResult {
 }
 
 enum RejectionReason {
-    REASON_GENERIC = 0; // Not a specific reason
-    REASON_NONE = 1; // Authorizer will send the error as string to GCS
-    REASON_INVALID_WAYPOINT = 2; // At least one waypoint have a invalid value
-    REASON_TIMEOUT = 3; // Timeout in the authorizer process(in case it depends on network)
-    REASON_AIRSPACE_IN_USE = 4; // Airspace of the mission in use by another vehicle, second result parameter can have the waypoint id that caused it to be denied.
-    REASON_BAD_WEATHER = 5; // Weather is not good to fly
+    REJECTION_REASON_GENERIC = 0; // Not a specific reason
+    REJECTION_REASON_NONE = 1; // Authorizer will send the error as string to GCS
+    REJECTION_REASON_INVALID_WAYPOINT = 2; // At least one waypoint have a invalid value
+    REJECTION_REASON_TIMEOUT = 3; // Timeout in the authorizer process(in case it depends on network)
+    REJECTION_REASON_AIRSPACE_IN_USE = 4; // Airspace of the mission in use by another vehicle, second result parameter can have the waypoint id that caused it to be denied.
+    REJECTION_REASON_BAD_WEATHER = 5; // Weather is not good to fly
 }

--- a/protos/arm_authorizer_server/arm_authorizer_server.proto
+++ b/protos/arm_authorizer_server/arm_authorizer_server.proto
@@ -1,0 +1,61 @@
+syntax = "proto3";
+
+package mavsdk.rpc.arm_authorizer;
+
+import "mavsdk_options.proto";
+
+option java_package = "io.mavsdk.arm_authorizer";
+option java_outer_classname = "ArmAuthorizerProto";
+
+service ArmAuthorizerServerService {
+    // Subscribe to arm authorization request messages. Each request received should respond to using RespondArmAuthorization
+    rpc SubscribeArmAuthorization(SubscribeArmAuthorizationRequest) returns(stream SubscribeArmAuthorizationResponse) { option (mavsdk.options.async_type) = ASYNC; }
+
+    // Authorize arm for the specific time
+    rpc AcceptArmAuthorization(AcceptArmAuthorizationRequest) returns(AcceptArmAuthorizationResponse) { option (mavsdk.options.async_type) = SYNC; }
+
+    // Reject arm authorization request
+    rpc RejectArmAuthorization(RejectArmAuthorizationRequest) returns(RejectArmAuthorizationResponse) { option (mavsdk.options.async_type) = SYNC; }
+}
+
+// Messages for SubscribeArmAuthorization
+message SubscribeArmAuthorizationRequest {}
+message SubscribeArmAuthorizationResponse {
+    uint32 system_id = 1; // vehicle system id
+}
+
+// Messages for RespondArmAuthorization
+message AcceptArmAuthorizationRequest {
+    int32 valid_time = 1; // Time in seconds for which this authorization is valid
+}
+
+// Result type
+message AcceptArmAuthorizationResponse {
+    CommandAnswer command_answer = 1; // Result enum value
+}
+
+// Messages for RespondArmAuthorization
+message RejectArmAuthorizationRequest {
+    bool temporarily = 1; // True if the answer should be TEMPORARILY_REJECTED, false for DENIED
+    RejectionReason reason = 2; // Reason for the arm to be rejected
+    int32 extra_info = 3; // Extra information specific to the rejection reason (see https://mavlink.io/en/services/arm_authorization.html)
+}
+
+// Result type
+message RejectArmAuthorizationResponse {
+    CommandAnswer command_answer = 1; // Result enum value
+}
+
+enum CommandAnswer {
+    COMMAND_ANSWER_ACCEPTED = 0; // Command accepted
+    COMMAND_ANSWER_FAILED = 1; // Command failed
+}
+
+enum RejectionReason {
+    REASON_GENERIC = 0; // Not a specific reason
+    REASON_NONE = 1; // Authorizer will send the error as string to GCS
+    REASON_INVALID_WAYPOINT = 2; // At least one waypoint have a invalid value
+    REASON_TIMEOUT = 3; // Timeout in the authorizer process(in case it depends on network)
+    REASON_AIRSPACE_IN_USE = 4; // Airspace of the mission in use by another vehicle, second result parameter can have the waypoint id that caused it to be denied.
+    REASON_BAD_WEATHER = 5; // Weather is not good to fly
+}


### PR DESCRIPTION
This PR adds the functionality of arm authorization server, as it is described by [MavLink arm authorization protocol](https://mavlink.io/en/services/arm_authorization.html). The server should be able to respond to `MAV_CMD_ARM_AUTHORIZATION_REQUEST` with a user specified callback and allow or reject arming, requested by a vehicle. I also created a [PR into MAVSDK](https://github.com/mavlink/MAVSDK/pull/2267) with a C++ implementation and example