### PR TITLE
rtk: encode RTCM data in base64

### DIFF
--- a/protos/rtk/rtk.proto
+++ b/protos/rtk/rtk.proto
@@ -15,7 +15,7 @@ service RtkService {
 
 // RTCM data type
 message RtcmData {
-    string data = 1; // The data encoded as a string
+    string data_base64 = 1; // The data encoded as a base64 string
 }
 
 message SendRtcmDataRequest {


### PR DESCRIPTION
This makes it possible to use this via other languages like Python where binary data in a string is not an option.