### PR TITLE
log_streaming: make base64 format clearer

### DIFF
--- a/protos/log_streaming/log_streaming.proto
+++ b/protos/log_streaming/log_streaming.proto
@@ -34,7 +34,7 @@ message LogStreamingRawResponse {
 
 // Raw logging data type
 message LogStreamingRaw {
-    string data = 1; // Ulog file stream data encoded as base64
+    string data_base64 = 1; // Ulog file stream data encoded as base64
 }
 
 // Result type.


### PR DESCRIPTION
This way it's harder to miss this.