### PR TITLE
Updated proto `pb_plugin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.egg-info/
 *__pycache__/
 *.pyc
+.idea/
 pb_plugins/generated/
 build/
 dist/

--- a/pb_plugins/protoc_gen_mavsdk/__init__.py
+++ b/pb_plugins/protoc_gen_mavsdk/__init__.py
@@ -2,4 +2,4 @@
 """ Autogenerator for MAVSDK """
 
 
-from .autogen import AutoGen
+from protoc_gen_mavsdk.autogen import AutoGen

--- a/pb_plugins/protoc_gen_mavsdk/__main__.py
+++ b/pb_plugins/protoc_gen_mavsdk/__main__.py
@@ -3,7 +3,7 @@
 
 import sys
 from google.protobuf.compiler import plugin_pb2
-from . import AutoGen
+from protoc_gen_mavsdk.autogen import AutoGen
 
 
 def main():

--- a/pb_plugins/protoc_gen_mavsdk/autogen.py
+++ b/pb_plugins/protoc_gen_mavsdk/autogen.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from os import environ
 from google.protobuf.compiler import plugin_pb2
-from .autogen_file import File
-from .docs import Docs
-from .enum import Enum
-from .methods import Method
-from .struct import Struct
-from .utils import (get_template_env,
+from protoc_gen_mavsdk.autogen_file import File
+from protoc_gen_mavsdk.docs import Docs
+from protoc_gen_mavsdk.pb_enum import Enum
+from protoc_gen_mavsdk.methods import Method
+from protoc_gen_mavsdk.pb_struct import Struct
+from protoc_gen_mavsdk.utils import (get_template_env,
                     has_result,
                     is_server,
                     name_parser_factory,

--- a/pb_plugins/protoc_gen_mavsdk/autogen.py
+++ b/pb_plugins/protoc_gen_mavsdk/autogen.py
@@ -7,10 +7,10 @@ from protoc_gen_mavsdk.pb_enum import Enum
 from protoc_gen_mavsdk.methods import Method
 from protoc_gen_mavsdk.pb_struct import Struct
 from protoc_gen_mavsdk.utils import (get_template_env,
-                    has_result,
-                    is_server,
-                    name_parser_factory,
-                    type_info_factory)
+                                     has_result,
+                                     is_server,
+                                     name_parser_factory,
+                                     type_info_factory)
 
 
 class AutoGen(object):

--- a/pb_plugins/protoc_gen_mavsdk/autogen.py
+++ b/pb_plugins/protoc_gen_mavsdk/autogen.py
@@ -12,7 +12,6 @@ from .utils import (get_template_env,
                     name_parser_factory,
                     type_info_factory)
 
-import protoc_gen_mavsdk.mavsdk_options_pb2
 
 class AutoGen(object):
     """ Autogenerator for the MAVSDK bindings """

--- a/pb_plugins/protoc_gen_mavsdk/autogen_file.py
+++ b/pb_plugins/protoc_gen_mavsdk/autogen_file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .utils import name_parser_factory
+from protoc_gen_mavsdk.utils import name_parser_factory
 
 
 class File(object):

--- a/pb_plugins/protoc_gen_mavsdk/docs.py
+++ b/pb_plugins/protoc_gen_mavsdk/docs.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-
-
 class Docs:
     """
     Docs

--- a/pb_plugins/protoc_gen_mavsdk/docs.py
+++ b/pb_plugins/protoc_gen_mavsdk/docs.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-class Docs():
+class Docs:
     """
     Docs
 

--- a/pb_plugins/protoc_gen_mavsdk/mavsdk_options_pb2.py
+++ b/pb_plugins/protoc_gen_mavsdk/mavsdk_options_pb2.py
@@ -4,8 +4,6 @@
 
 from google.protobuf.internal import enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
-from google.protobuf import message as _message
-from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
 
 # @@protoc_insertion_point(imports)

--- a/pb_plugins/protoc_gen_mavsdk/mavsdk_options_pb2.py
+++ b/pb_plugins/protoc_gen_mavsdk/mavsdk_options_pb2.py
@@ -7,46 +7,45 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
-
 from google.protobuf import descriptor_pb2 as google_dot_protobuf_dot_descriptor__pb2
 
-
 DESCRIPTOR = _descriptor.FileDescriptor(
-  name='mavsdk_options.proto',
-  package='mavsdk.options',
-  syntax='proto3',
-  serialized_options=b'\n\016options.mavsdk',
-  serialized_pb=b'\n\x14mavsdk_options.proto\x12\x0emavsdk.options\x1a google/protobuf/descriptor.proto**\n\tAsyncType\x12\t\n\x05\x41SYNC\x10\x00\x12\x08\n\x04SYNC\x10\x01\x12\x08\n\x04\x42OTH\x10\x02:6\n\rdefault_value\x12\x1d.google.protobuf.FieldOptions\x18\xd0\x86\x03 \x01(\t:0\n\x07\x65psilon\x12\x1d.google.protobuf.FieldOptions\x18\xd1\x86\x03 \x01(\x01:O\n\nasync_type\x12\x1e.google.protobuf.MethodOptions\x18\xd0\x86\x03 \x01(\x0e\x32\x19.mavsdk.options.AsyncType:3\n\tis_finite\x12\x1e.google.protobuf.MethodOptions\x18\xd1\x86\x03 \x01(\x08\x42\x10\n\x0eoptions.mavsdkb\x06proto3'
-  ,
-  dependencies=[google_dot_protobuf_dot_descriptor__pb2.DESCRIPTOR,])
+    name='mavsdk_options.proto',
+    package='mavsdk.options',
+    syntax='proto3',
+    serialized_options=b'\n\016options.mavsdk',
+    serialized_pb=b'\n\x14mavsdk_options.proto\x12\x0emavsdk.options\x1a google/protobuf/descriptor.proto**\n\tAsyncType\x12\t\n\x05\x41SYNC\x10\x00\x12\x08\n\x04SYNC\x10\x01\x12\x08\n\x04\x42OTH\x10\x02:6\n\rdefault_value\x12\x1d.google.protobuf.FieldOptions\x18\xd0\x86\x03 \x01(\t:0\n\x07\x65psilon\x12\x1d.google.protobuf.FieldOptions\x18\xd1\x86\x03 \x01(\x01:O\n\nasync_type\x12\x1e.google.protobuf.MethodOptions\x18\xd0\x86\x03 \x01(\x0e\x32\x19.mavsdk.options.AsyncType:3\n\tis_finite\x12\x1e.google.protobuf.MethodOptions\x18\xd1\x86\x03 \x01(\x08\x42\x10\n\x0eoptions.mavsdkb\x06proto3'
+    ,
+    dependencies=[google_dot_protobuf_dot_descriptor__pb2.DESCRIPTOR, ])
 
 _ASYNCTYPE = _descriptor.EnumDescriptor(
-  name='AsyncType',
-  full_name='mavsdk.options.AsyncType',
-  filename=None,
-  file=DESCRIPTOR,
-  values=[
-    _descriptor.EnumValueDescriptor(
-      name='ASYNC', index=0, number=0,
-      serialized_options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='SYNC', index=1, number=1,
-      serialized_options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='BOTH', index=2, number=2,
-      serialized_options=None,
-      type=None),
-  ],
-  containing_type=None,
-  serialized_options=None,
-  serialized_start=74,
-  serialized_end=116,
+    name='AsyncType',
+    full_name='mavsdk.options.AsyncType',
+    filename=None,
+    file=DESCRIPTOR,
+    values=[
+        _descriptor.EnumValueDescriptor(
+            name='ASYNC', index=0, number=0,
+            serialized_options=None,
+            type=None),
+        _descriptor.EnumValueDescriptor(
+            name='SYNC', index=1, number=1,
+            serialized_options=None,
+            type=None),
+        _descriptor.EnumValueDescriptor(
+            name='BOTH', index=2, number=2,
+            serialized_options=None,
+            type=None),
+    ],
+    containing_type=None,
+    serialized_options=None,
+    serialized_start=74,
+    serialized_end=116,
 )
 _sym_db.RegisterEnumDescriptor(_ASYNCTYPE)
 
@@ -57,36 +56,36 @@ BOTH = 2
 
 DEFAULT_VALUE_FIELD_NUMBER = 50000
 default_value = _descriptor.FieldDescriptor(
-  name='default_value', full_name='mavsdk.options.default_value', index=0,
-  number=50000, type=9, cpp_type=9, label=1,
-  has_default_value=False, default_value=b"".decode('utf-8'),
-  message_type=None, enum_type=None, containing_type=None,
-  is_extension=True, extension_scope=None,
-  serialized_options=None, file=DESCRIPTOR)
+    name='default_value', full_name='mavsdk.options.default_value', index=0,
+    number=50000, type=9, cpp_type=9, label=1,
+    has_default_value=False, default_value=b"".decode('utf-8'),
+    message_type=None, enum_type=None, containing_type=None,
+    is_extension=True, extension_scope=None,
+    serialized_options=None, file=DESCRIPTOR)
 EPSILON_FIELD_NUMBER = 50001
 epsilon = _descriptor.FieldDescriptor(
-  name='epsilon', full_name='mavsdk.options.epsilon', index=1,
-  number=50001, type=1, cpp_type=5, label=1,
-  has_default_value=False, default_value=float(0),
-  message_type=None, enum_type=None, containing_type=None,
-  is_extension=True, extension_scope=None,
-  serialized_options=None, file=DESCRIPTOR)
+    name='epsilon', full_name='mavsdk.options.epsilon', index=1,
+    number=50001, type=1, cpp_type=5, label=1,
+    has_default_value=False, default_value=float(0),
+    message_type=None, enum_type=None, containing_type=None,
+    is_extension=True, extension_scope=None,
+    serialized_options=None, file=DESCRIPTOR)
 ASYNC_TYPE_FIELD_NUMBER = 50000
 async_type = _descriptor.FieldDescriptor(
-  name='async_type', full_name='mavsdk.options.async_type', index=2,
-  number=50000, type=14, cpp_type=8, label=1,
-  has_default_value=False, default_value=0,
-  message_type=None, enum_type=None, containing_type=None,
-  is_extension=True, extension_scope=None,
-  serialized_options=None, file=DESCRIPTOR)
+    name='async_type', full_name='mavsdk.options.async_type', index=2,
+    number=50000, type=14, cpp_type=8, label=1,
+    has_default_value=False, default_value=0,
+    message_type=None, enum_type=None, containing_type=None,
+    is_extension=True, extension_scope=None,
+    serialized_options=None, file=DESCRIPTOR)
 IS_FINITE_FIELD_NUMBER = 50001
 is_finite = _descriptor.FieldDescriptor(
-  name='is_finite', full_name='mavsdk.options.is_finite', index=3,
-  number=50001, type=8, cpp_type=7, label=1,
-  has_default_value=False, default_value=False,
-  message_type=None, enum_type=None, containing_type=None,
-  is_extension=True, extension_scope=None,
-  serialized_options=None, file=DESCRIPTOR)
+    name='is_finite', full_name='mavsdk.options.is_finite', index=3,
+    number=50001, type=8, cpp_type=7, label=1,
+    has_default_value=False, default_value=False,
+    message_type=None, enum_type=None, containing_type=None,
+    is_extension=True, extension_scope=None,
+    serialized_options=None, file=DESCRIPTOR)
 
 DESCRIPTOR.enum_types_by_name['AsyncType'] = _ASYNCTYPE
 DESCRIPTOR.extensions_by_name['default_value'] = default_value

--- a/pb_plugins/protoc_gen_mavsdk/methods.py
+++ b/pb_plugins/protoc_gen_mavsdk/methods.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-from .utils import (filter_out_result,
-                    is_stream,
-                    name_parser_factory,
-                    no_return,
-                    Param,
-                    remove_subscribe,
-                    type_info_factory)
+from protoc_gen_mavsdk.utils import (filter_out_result,
+                                     is_stream,
+                                     name_parser_factory,
+                                     no_return,
+                                     Param,
+                                     remove_subscribe,
+                                     type_info_factory)
 
 
 class Method(object):

--- a/pb_plugins/protoc_gen_mavsdk/name_parser.py
+++ b/pb_plugins/protoc_gen_mavsdk/name_parser.py
@@ -1,8 +1,6 @@
 import json
 import re
 
-from os import environ
-
 
 class NameParserFactory:
     _initialisms = []

--- a/pb_plugins/protoc_gen_mavsdk/name_parser.py
+++ b/pb_plugins/protoc_gen_mavsdk/name_parser.py
@@ -3,6 +3,7 @@ import re
 
 from os import environ
 
+
 class NameParserFactory:
     _initialisms = []
 

--- a/pb_plugins/protoc_gen_mavsdk/pb_enum.py
+++ b/pb_plugins/protoc_gen_mavsdk/pb_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .utils import name_parser_factory
+from protoc_gen_mavsdk.utils import name_parser_factory
 
 
 class Enum(object):

--- a/pb_plugins/protoc_gen_mavsdk/pb_struct.py
+++ b/pb_plugins/protoc_gen_mavsdk/pb_struct.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
-
-
-from .enum import Enum
-from .utils import (is_request,
-                    is_response,
-                    is_struct,
-                    name_parser_factory,
-                    Param,
-                    type_info_factory)
+from protoc_gen_mavsdk.pb_enum import Enum
+from protoc_gen_mavsdk.utils import (is_request,
+                                     is_response,
+                                     is_struct,
+                                     name_parser_factory,
+                                     Param,
+                                     type_info_factory)
 
 
 class Struct(object):

--- a/pb_plugins/protoc_gen_mavsdk/struct.py
+++ b/pb_plugins/protoc_gen_mavsdk/struct.py
@@ -8,7 +8,6 @@ from .utils import (is_request,
                     name_parser_factory,
                     Param,
                     type_info_factory)
-from jinja2.exceptions import TemplateNotFound
 
 
 class Struct(object):

--- a/pb_plugins/protoc_gen_mavsdk/utils.py
+++ b/pb_plugins/protoc_gen_mavsdk/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from jinja2 import Environment, FileSystemLoader
-from .name_parser import NameParserFactory
-from .type_info import TypeInfoFactory
+from protoc_gen_mavsdk.name_parser import NameParserFactory
+from protoc_gen_mavsdk.type_info import TypeInfoFactory
 
 
 name_parser_factory = NameParserFactory()

--- a/pb_plugins/requirements.txt
+++ b/pb_plugins/requirements.txt
@@ -1,2 +1,2 @@
-protobuf>=3.13,<=3.20.1
-jinja2>=2.11
+protobuf>=5.27.1
+jinja2>=3.1.4

--- a/pb_plugins/setup.py
+++ b/pb_plugins/setup.py
@@ -1,10 +1,7 @@
 import os
-import subprocess
-import sys
 
-from distutils.command.build import build
-from distutils.spawn import find_executable
 from setuptools import setup
+
 
 def parse_requirements(filename):
     """
@@ -25,6 +22,7 @@ def parse_requirements(filename):
     # Parse install requirements
     with open(filepath, encoding="utf-8") as f:
         return [requires.strip() for requires in f.readlines()]
+
 
 setup(
     name="protoc-gen-mavsdk",

--- a/pb_plugins/test/test_name_parser.py
+++ b/pb_plugins/test/test_name_parser.py
@@ -3,8 +3,8 @@ import unittest
 from protoc_gen_mavsdk.name_parser import (NameParser, NameParserFactory)
 from unittest.mock import patch, mock_open
 
-class TestNameParser(unittest.TestCase):
 
+class TestNameParser(unittest.TestCase):
     _initialisms_data = """ ["HTTP", "HTTPS", "URL", "ID"] """
 
     def setUp(self):
@@ -164,7 +164,7 @@ class TestNameParser(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_initialisms_data)
     def test_initalism_is_capitalized_when_camel_case(self, mock_file):
         name_parser_factory = NameParserFactory()
-        name_parser_factory.set_template_path("random/path")
+        name_parser_factory.set_initialisms_path("random/path")
         name = name_parser_factory.create("fileUrl")
 
         self.assertEqual("FileURL", name.upper_camel_case)
@@ -173,7 +173,7 @@ class TestNameParser(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_initialisms_data)
     def test_initalism_is_capitalized_when_upper_snake_case(self, mock_file):
         name_parser_factory = NameParserFactory()
-        name_parser_factory.set_template_path("random/path")
+        name_parser_factory.set_initialisms_path("random/path")
         name = name_parser_factory.create("fileUrl")
 
         self.assertEqual("File_URL", name.upper_snake_case)
@@ -181,7 +181,7 @@ class TestNameParser(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_initialisms_data)
     def test_initalism_is_not_capitalized_when_lower_snake_case(self, mock_file):
         name_parser_factory = NameParserFactory()
-        name_parser_factory.set_template_path("random/path")
+        name_parser_factory.set_initialisms_path("random/path")
         name = name_parser_factory.create("fileUrl")
 
         self.assertEqual("file_url", name.lower_snake_case)

--- a/pb_plugins/test/test_type_info.py
+++ b/pb_plugins/test/test_type_info.py
@@ -1,11 +1,11 @@
 import unittest
 
 from collections import namedtuple
-from protoc_gen_mavsdk.type_info import (TypeInfo, TypeInfoFactory)
+from protoc_gen_mavsdk.type_info import TypeInfoFactory
 from unittest.mock import patch, mock_open
 
-class TestTypeInfo(unittest.TestCase):
 
+class TestTypeInfo(unittest.TestCase):
     _conversion_dict_data = """ {
         "bool": "converted_bool"
     } """
@@ -42,7 +42,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_uses_default_when_no_conversion(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         type_info = type_info_factory.create(self.primitive_field(self.double_id, self.non_repeated_label))
 
         self.assertEqual(type_info.name, self.double_expected_default_str)
@@ -50,7 +50,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_converts_type_when_conversion(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         type_info = type_info_factory.create(self.primitive_field(self.bool_id, self.non_repeated_label))
 
         self.assertEqual(type_info.name, self.bool_expected_converted_str)
@@ -58,16 +58,16 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_raises_error_when_invalid_type(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         type_info = type_info_factory.create(self.primitive_field(self.invalid_id, self.non_repeated_label))
 
         with self.assertRaises(ValueError):
-            type_info.name
+            var = type_info.name
 
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_primitive_false_for_complex_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
 
         for type_id in {11, 14}:
             non_primitive_type = type_info_factory.create(self.primitive_field(type_id, self.non_repeated_label))
@@ -76,7 +76,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_primitive_true_for_primitive_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
 
         for type_id in {1, 2, 3, 4, 5, 8, 9, 12, 13}:
             primitive_type = type_info_factory.create(self.primitive_field(type_id, self.non_repeated_label))
@@ -85,7 +85,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_enum_true_for_enum_type(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
 
         enum_type = type_info_factory.create(self.non_primitive_field(14, "SomeNonResultType", self.repeated_label))
         self.assertTrue(enum_type.is_enum)
@@ -93,7 +93,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_is_result_false_for_primitive_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
 
         for type_id in {1, 2, 3, 4, 5, 8, 9, 12, 13}:
             primitive_type = type_info_factory.create(self.primitive_field(type_id, self.non_repeated_label))
@@ -102,7 +102,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_is_result_false_for_complex_non_result_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
 
         for type_id in {11, 14}:
             complex_type = type_info_factory.create(self.non_primitive_field(type_id, "SomeNonResultType", self.non_repeated_label))
@@ -111,7 +111,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_is_string_false_for_non_string_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
 
         for type_id in {1, 2, 3, 4, 5, 8, 12, 13}:
             string_type = type_info_factory.create(self.primitive_field(type_id, self.non_repeated_label))
@@ -120,7 +120,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_is_string_true_for_string_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
 
         for type_id in {9}:
             string_type = type_info_factory.create(self.primitive_field(type_id, self.non_repeated_label))
@@ -129,7 +129,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_is_result_true_for_result_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
 
         for type_id in {11, 14}:
             complex_type = type_info_factory.create(self.non_primitive_field(type_id, "SomeResult", self.non_repeated_label))
@@ -138,7 +138,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_repeated_false_for_non_repeated_primitive(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         non_repeated_primitive_type = type_info_factory.create(self.primitive_field(self.double_id, self.non_repeated_label))
 
         self.assertFalse(non_repeated_primitive_type.is_repeated)
@@ -146,7 +146,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_repeated_true_for_repeated_primitive(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         repeated_primitive_type = type_info_factory.create(self.primitive_field(self.double_id, self.repeated_label))
 
         self.assertTrue(repeated_primitive_type.is_repeated)
@@ -154,7 +154,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_repeated_false_for_non_repeated(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         non_repeated_type = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.non_repeated_label))
 
         self.assertFalse(non_repeated_type.is_repeated)
@@ -162,7 +162,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_repeated_true_for_repeated(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         repeated_type = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
 
         self.assertTrue(repeated_type.is_repeated)
@@ -170,7 +170,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_name_adds_prefix_suffix_for_repeated_primitive(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         type_info = type_info_factory.create(self.primitive_field(self.double_id, self.repeated_label))
 
         self.assertEqual(type_info.name, "prefix[double]suffix")
@@ -178,7 +178,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_adds_default_prefix_suffix_when_repeated_primitive_not_in_conversion_dict(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         type_info = type_info_factory.create(self.primitive_field(self.double_id, self.repeated_label))
 
         self.assertEqual(type_info.name, "std::vector<double>")
@@ -186,7 +186,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_name_adds_prefix_suffix_for_repeated(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         type_info = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
 
         self.assertEqual(type_info.name, "prefix[SomeNonResultType]suffix")
@@ -194,7 +194,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_adds_default_prefix_suffix_when_repeated_not_in_conversion_dict(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         type_info = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
 
         self.assertEqual(type_info.name, "std::vector<SomeNonResultType>")
@@ -202,7 +202,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_inner_name_for_repeated(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info_factory.set_template_path("random/path")
+        type_info_factory.set_conversion_path("random/path")
         type_info = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
 
         self.assertEqual(type_info.inner_name, "SomeNonResultType")


### PR DESCRIPTION
Whilst attempting to fix issues within MAVSDK-Python outlined [here](https://github.com/mavlink/MAVSDK-Python/issues/698), I noticed dependency conflicts arising from the fact that the `pb_plugin` utilises very old versions of `protobuf`.

Updated those dependencies and formatted the project. Also fixed a few failing tests