### PR TITLE
Added outgoing mission response subscription API

### DIFF
--- a/protos/mission_raw_server/mission_raw_server.proto
+++ b/protos/mission_raw_server/mission_raw_server.proto
@@ -16,6 +16,11 @@ service MissionRawServerService {
     rpc SubscribeIncomingMission(SubscribeIncomingMissionRequest) returns(stream IncomingMissionResponse) {}
 
     /*
+     * Subscribe to the result of outgoing mission download requests (air to ground)
+     */
+    rpc SubscribeOutgoingMissionResult(SubscribeOutgoingMissionRequest) returns(stream OutgoingMissionResult) {}
+
+    /*
      * Subscribe to when a new current item is set
      */
     rpc SubscribeCurrentItemChanged(SubscribeCurrentItemChangedRequest) returns(stream CurrentItemChangedResponse) {}
@@ -35,6 +40,11 @@ message SubscribeIncomingMissionRequest {}
 message IncomingMissionResponse {
     MissionRawServerResult mission_raw_server_result = 1;
     MissionPlan mission_plan = 2; // The mission plan
+}
+
+message SubscribeOutgoingMissionRequest {}
+message OutgoingMissionResult {
+    MissionRawServerResult mission_raw_server_result = 1;
 }
 
 message SubscribeCurrentItemChangedRequest {}


### PR DESCRIPTION
gRPC definitions to accompany the changes to `MissionRawServer` in this PR:
https://github.com/mavlink/MAVSDK/pull/2463

Refer to the MAVSDK pull request for implementation details and results.