### PR TITLE
API for receiving status notifications on outgoing mission requests

### DIFF
--- a/protos/mission_raw_server/mission_raw_server.proto
+++ b/protos/mission_raw_server/mission_raw_server.proto
@@ -16,6 +16,11 @@ service MissionRawServerService {
     rpc SubscribeIncomingMission(SubscribeIncomingMissionRequest) returns(stream IncomingMissionResponse) {}
 
     /*
+     * Subscribe to when a new mission download request completes (asynchronous)
+     */
+    rpc SubscribeOutgoingMission(SubscribeOutgoingMissionRequest) returns(stream OutgoingMissionResponse) { option (mavsdk.options.async_type) = ASYNC; }
+
+    /*
      * Subscribe to when a new current item is set
      */
     rpc SubscribeCurrentItemChanged(SubscribeCurrentItemChangedRequest) returns(stream CurrentItemChangedResponse) {}
@@ -35,6 +40,12 @@ message SubscribeIncomingMissionRequest {}
 message IncomingMissionResponse {
     MissionRawServerResult mission_raw_server_result = 1;
     MissionPlan mission_plan = 2; // The mission plan
+}
+
+message SubscribeOutgoingMissionRequest {}
+message OutgoingMissionResponse {
+    MissionRawServerResult mission_raw_server_result = 1;
+    MissionPlan mission_plan = 2; // The mission plan that was requested
 }
 
 message SubscribeCurrentItemChangedRequest {}


### PR DESCRIPTION
This is a companion PR for the main implementation in MAVSDK:
https://github.com/mavlink/MAVSDK/pull/2463

Details can be found in the MAVSDK PR.