### PR TITLE
mission_raw_server: make subscriptions async only

### DIFF
--- a/protos/mission_raw_server/mission_raw_server.proto
+++ b/protos/mission_raw_server/mission_raw_server.proto
@@ -13,12 +13,12 @@ service MissionRawServerService {
     /*
      * Subscribe to when a new mission is uploaded (asynchronous).
      */
-    rpc SubscribeIncomingMission(SubscribeIncomingMissionRequest) returns(stream IncomingMissionResponse) {}
+    rpc SubscribeIncomingMission(SubscribeIncomingMissionRequest) returns(stream IncomingMissionResponse) { option (mavsdk.options.async_type) = ASYNC; }
 
     /*
      * Subscribe to when a new current item is set
      */
-    rpc SubscribeCurrentItemChanged(SubscribeCurrentItemChangedRequest) returns(stream CurrentItemChangedResponse) {}
+    rpc SubscribeCurrentItemChanged(SubscribeCurrentItemChangedRequest) returns(stream CurrentItemChangedResponse) { option (mavsdk.options.async_type) = ASYNC; }
 
     /*
      *  Set Current item as completed
@@ -28,7 +28,7 @@ service MissionRawServerService {
     /*
      *  Subscribe when a MISSION_CLEAR_ALL is received
      */
-    rpc SubscribeClearAll(SubscribeClearAllRequest) returns(stream ClearAllResponse) {}
+    rpc SubscribeClearAll(SubscribeClearAllRequest) returns(stream ClearAllResponse) { option (mavsdk.options.async_type) = ASYNC; }
 }
 
 message SubscribeIncomingMissionRequest {}


### PR DESCRIPTION
PR #352 introduced breaking changes for MAVSDK main. The MAVSDK PR that would fix that is here, and has been open since august: https://github.com/mavlink/MAVSDK/pull/2386. In order to be able to make changes to the submodule on MAVSDK main without requiring MAVSDK 2386 to merge, these changes will need to be reverted.