### PR TITLE
Revert "Added API for receiving status notifications on outgoing mission requests"

### DIFF
--- a/protos/mission_raw_server/mission_raw_server.proto
+++ b/protos/mission_raw_server/mission_raw_server.proto
@@ -16,11 +16,6 @@ service MissionRawServerService {
     rpc SubscribeIncomingMission(SubscribeIncomingMissionRequest) returns(stream IncomingMissionResponse) {}
 
     /*
-     * Subscribe to when a new mission download request completes (asynchronous)
-     */
-    rpc SubscribeOutgoingMission(SubscribeOutgoingMissionRequest) returns(stream OutgoingMissionResponse) { option (mavsdk.options.async_type) = ASYNC; }
-
-    /*
      * Subscribe to when a new current item is set
      */
     rpc SubscribeCurrentItemChanged(SubscribeCurrentItemChangedRequest) returns(stream CurrentItemChangedResponse) {}
@@ -40,12 +35,6 @@ message SubscribeIncomingMissionRequest {}
 message IncomingMissionResponse {
     MissionRawServerResult mission_raw_server_result = 1;
     MissionPlan mission_plan = 2; // The mission plan
-}
-
-message SubscribeOutgoingMissionRequest {}
-message OutgoingMissionResponse {
-    MissionRawServerResult mission_raw_server_result = 1;
-    MissionPlan mission_plan = 2; // The mission plan that was requested
 }
 
 message SubscribeCurrentItemChangedRequest {}


### PR DESCRIPTION
I made a mess and need to revert this one for now.

This reverts commit c6089e77eb621ceee89a7d528444bd19de6983ec.