### PR TITLE
Bump to 1.2.0

### DIFF
--- a/pb_plugins/setup.py
+++ b/pb_plugins/setup.py
@@ -26,7 +26,7 @@ def parse_requirements(filename):
 
 setup(
     name="protoc-gen-mavsdk",
-    version="1.1.1",
+    version="1.2.0",
     description="Protoc plugin used to generate MAVSDK bindings",
     url="https://github.com/mavlink/MAVSDK-Proto",
     maintainer="Jonas Vautherin, Julian Oes",


### PR DESCRIPTION
This is needed for deployment, otherwise it tries to overwrite 1.1.1 and fails (see [here](https://github.com/mavlink/MAVSDK-Proto/actions/runs/12862022784/job/36055095760)) 👍.