### PR TITLE
Telemetry and TelemetryServer improvements

### DIFF
--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -759,7 +759,7 @@ message FixedwingMetrics {
     float climb_rate_m_s = 3 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
     float groundspeed_m_s = 4 [(mavsdk.options.default_value)="NaN"]; // Current groundspeed metres per second
     float heading_deg = 5 [(mavsdk.options.default_value)="NaN"]; // Current heading in compass units (0-360, 0=north)
-    float altitude_msl = 6 [(mavsdk.options.default_value)="NaN"]; // Current altitude in metres (MSL)
+    float absolute_altitude_m = 6 [(mavsdk.options.default_value)="NaN"]; // Current altitude in metres (MSL)
 }
 
 // AccelerationFrd message type.

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -755,11 +755,11 @@ message GroundTruth {
 // FixedwingMetrics message type.
 message FixedwingMetrics {
     float airspeed_m_s = 1 [(mavsdk.options.default_value)="NaN"]; // Current indicated airspeed (IAS) in metres per second
-    float groundspeed_m_s = 2 [(mavsdk.options.default_value)="NaN"]; // Current groundspeed metres per second
-    float heading_deg = 3 [(mavsdk.options.default_value)="NaN"]; // Current heading in compass units (0-360, 0=north)
-    float throttle_percentage = 4 [(mavsdk.options.default_value)="NaN"]; // Current throttle setting (0 to 100)
-    float altitude_msl = 5 [(mavsdk.options.default_value)="NaN"]; // Current altitude in metres (MSL)
-    float climb_rate_m_s = 6 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
+    float throttle_percentage = 2 [(mavsdk.options.default_value)="NaN"]; // Current throttle setting (0 to 100)
+    float climb_rate_m_s = 3 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
+    float groundspeed_m_s = 4 [(mavsdk.options.default_value)="NaN"]; // Current groundspeed metres per second
+    float heading_deg = 5 [(mavsdk.options.default_value)="NaN"]; // Current heading in compass units (0-360, 0=north)
+    float altitude_msl = 6 [(mavsdk.options.default_value)="NaN"]; // Current altitude in metres (MSL)
 }
 
 // AccelerationFrd message type.

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -755,8 +755,11 @@ message GroundTruth {
 // FixedwingMetrics message type.
 message FixedwingMetrics {
     float airspeed_m_s = 1 [(mavsdk.options.default_value)="NaN"]; // Current indicated airspeed (IAS) in metres per second
-    float throttle_percentage = 2 [(mavsdk.options.default_value)="NaN"]; // Current throttle setting (0 to 100)
-    float climb_rate_m_s = 3 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
+    float groundspeed_m_s = 2 [(mavsdk.options.default_value)="NaN"]; // Current groundspeed metres per second
+    float heading_deg = 3 [(mavsdk.options.default_value)="NaN"]; // Current heading in compass units (0-360, 0=north)
+    float throttle_percentage = 4 [(mavsdk.options.default_value)="NaN"]; // Current throttle setting (0 to 100)
+    float altitude_msl = 5 [(mavsdk.options.default_value)="NaN"]; // Current altitude in metres (MSL)
+    float climb_rate_m_s = 6 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
 }
 
 // AccelerationFrd message type.

--- a/protos/telemetry_server/telemetry_server.proto
+++ b/protos/telemetry_server/telemetry_server.proto
@@ -460,7 +460,7 @@ message FixedwingMetrics {
     float climb_rate_m_s = 3 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
     float groundspeed_m_s = 4 [(mavsdk.options.default_value)="NaN"]; // Current groundspeed metres per second
     float heading_deg = 5 [(mavsdk.options.default_value)="NaN"]; // Current heading in compass units (0-360, 0=north)
-    float altitude_msl = 6 [(mavsdk.options.default_value)="NaN"]; // Current altitude in metres (MSL)
+    float absolute_altitude_m = 6 [(mavsdk.options.default_value)="NaN"]; // Current altitude in metres (MSL)
 }
 
 // AccelerationFrd message type.

--- a/protos/telemetry_server/telemetry_server.proto
+++ b/protos/telemetry_server/telemetry_server.proto
@@ -456,11 +456,11 @@ message GroundTruth {
 // FixedwingMetrics message type.
 message FixedwingMetrics {
     float airspeed_m_s = 1 [(mavsdk.options.default_value)="NaN"]; // Current indicated airspeed (IAS) in metres per second
-    float groundspeed_m_s = 2 [(mavsdk.options.default_value)="NaN"]; // Current groundspeed metres per second
-    float heading_deg = 3 [(mavsdk.options.default_value)="NaN"]; // Current heading in compass units (0-360, 0=north)
-    float throttle_percentage = 4 [(mavsdk.options.default_value)="NaN"]; // Current throttle setting (0 to 100)
-    float altitude_msl = 5 [(mavsdk.options.default_value)="NaN"]; // Current altitude in metres (MSL)
-    float climb_rate_m_s = 6 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
+    float throttle_percentage = 2 [(mavsdk.options.default_value)="NaN"]; // Current throttle setting (0 to 100)
+    float climb_rate_m_s = 3 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
+    float groundspeed_m_s = 4 [(mavsdk.options.default_value)="NaN"]; // Current groundspeed metres per second
+    float heading_deg = 5 [(mavsdk.options.default_value)="NaN"]; // Current heading in compass units (0-360, 0=north)
+    float altitude_msl = 6 [(mavsdk.options.default_value)="NaN"]; // Current altitude in metres (MSL)
 }
 
 // AccelerationFrd message type.

--- a/protos/telemetry_server/telemetry_server.proto
+++ b/protos/telemetry_server/telemetry_server.proto
@@ -42,6 +42,10 @@ service TelemetryServerService {
     rpc PublishUnixEpochTime(PublishUnixEpochTimeRequest) returns(PublishUnixEpochTimeResponse) { option (mavsdk.options.async_type) = SYNC; }
     // Publish to "distance sensor" updates.
     rpc PublishDistanceSensor(PublishDistanceSensorRequest) returns(PublishDistanceSensorResponse) { option (mavsdk.options.async_type) = SYNC; }
+    // Publish to "attitude" updates.
+    rpc PublishAttitude(PublishAttitudeRequest) returns(PublishAttitudeResponse) { option (mavsdk.options.async_type) = SYNC; }
+    // Publish to "Visual Flight Rules HUD" updates.
+    rpc PublishVisualFlightRulesHud(PublishVisualFlightRulesHudRequest) returns(PublishVisualFlightRulesHudResponse) { option (mavsdk.options.async_type) = SYNC; }
 }
 
 message PublishPositionRequest {
@@ -125,6 +129,15 @@ message PublishDistanceSensorRequest {
     DistanceSensor distance_sensor = 1; // The next 'Distance Sensor' status
 }
 
+message PublishAttitudeRequest {
+    EulerAngle angle = 1; // roll/pitch/yaw body angles
+    AngularVelocityBody angular_velocity = 2; // roll/pitch/yaw angular velocities
+}
+
+message PublishVisualFlightRulesHudRequest {
+    FixedwingMetrics fixed_wing_metrics = 1;
+}
+
 message PublishPositionResponse {
     TelemetryServerResult telemetry_server_result = 1;
 }
@@ -184,6 +197,14 @@ message PublishUnixEpochTimeResponse {
 }
 
 message PublishDistanceSensorResponse {
+    TelemetryServerResult telemetry_server_result = 1;
+}
+
+message PublishAttitudeResponse {
+    TelemetryServerResult telemetry_server_result = 1;
+}
+
+message PublishVisualFlightRulesHudResponse {
     TelemetryServerResult telemetry_server_result = 1;
 }
 
@@ -435,8 +456,11 @@ message GroundTruth {
 // FixedwingMetrics message type.
 message FixedwingMetrics {
     float airspeed_m_s = 1 [(mavsdk.options.default_value)="NaN"]; // Current indicated airspeed (IAS) in metres per second
-    float throttle_percentage = 2 [(mavsdk.options.default_value)="NaN"]; // Current throttle setting (0 to 100)
-    float climb_rate_m_s = 3 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
+    float groundspeed_m_s = 2 [(mavsdk.options.default_value)="NaN"]; // Current groundspeed metres per second
+    float heading_deg = 3 [(mavsdk.options.default_value)="NaN"]; // Current heading in compass units (0-360, 0=north)
+    float throttle_percentage = 4 [(mavsdk.options.default_value)="NaN"]; // Current throttle setting (0 to 100)
+    float altitude_msl = 5 [(mavsdk.options.default_value)="NaN"]; // Current altitude in metres (MSL)
+    float climb_rate_m_s = 6 [(mavsdk.options.default_value)="NaN"]; // Current climb rate in metres per second
 }
 
 // AccelerationFrd message type.


### PR DESCRIPTION
Changes to support the corresponding MAVSDK PR: https://github.com/mavlink/MAVSDK/pull/2504

Specifically:
  - Filled out the FixedwingMetrics struct to include the rest of the fields in the MAVLINK VFR_HUD message
  - Added an Attitude message for the TelemetryServer for symmetry with the Telemetry class

Note that currently MAVSDK does not build against Proto main. The MAVSDK PR listed above is using a branch of Proto with changes cherry-picked.