### PR TITLE
telemetry: add comment regarding RawImu units

### DIFF
--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -62,7 +62,7 @@ service TelemetryService {
     rpc SubscribeImu(SubscribeImuRequest) returns(stream ImuResponse) {}
     // Subscribe to 'Scaled IMU' updates.
     rpc SubscribeScaledImu(SubscribeScaledImuRequest) returns(stream ScaledImuResponse) {}
-    // Subscribe to 'Raw IMU' updates.
+    // Subscribe to 'Raw IMU' updates (note that units are are incorrect and "raw" as provided by the sensor)
     rpc SubscribeRawImu(SubscribeRawImuRequest) returns(stream RawImuResponse) {}
     // Subscribe to 'HealthAllOk' updates.
     rpc SubscribeHealthAllOk(SubscribeHealthAllOkRequest) returns(stream HealthAllOkResponse) {}


### PR DESCRIPTION
These are - by the MAVLink spec - just raw, without unit. Our types are misleading and wrong. The least we can do is to flag this as incorrect.

For the next release we should probably remove this debug telemetry feature.