### PR TITLE
telemetry: add energy_consumed_wh to Battery

### DIFF
--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -625,6 +625,7 @@ message Battery {
     float remaining_percent = 6 [(mavsdk.options.default_value)="NaN"]; // Estimated battery remaining (range: 0 to 100)
     float time_remaining_s = 7 [(mavsdk.options.default_value)="NaN"]; // Estimated battery usage time remaining 
     BatteryFunction battery_function = 8; // Function of the battery
+    float energy_consumed_wh = 9 [(mavsdk.options.default_value)="NaN"]; // Consumed energy in Watt-hours, NAN if autopilot does not provide energy consumption estimate
 }
 
 /*


### PR DESCRIPTION
## Summary

Adds `energy_consumed_wh` as field 9 to the `Battery` message in `telemetry.proto`.

This exposes the `energy_consumed` field from the MAVLink `BATTERY_STATUS` message. The implementation in MAVSDK converts from hectojoules (hJ, the MAVLink unit) to Watt-hours by dividing by 36. The sentinel value −1 (field not available) maps to `NaN`.

**Companion PR:** mavlink/MAVSDK#2882

Fixes https://github.com/mavlink/MAVSDK/issues/1748
