### PR TITLE
Revert "telemetry: add energy_consumed_wh to Battery (#408)"

### DIFF
--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -625,7 +625,6 @@ message Battery {
     float remaining_percent = 6 [(mavsdk.options.default_value)="NaN"]; // Estimated battery remaining (range: 0 to 100)
     float time_remaining_s = 7 [(mavsdk.options.default_value)="NaN"]; // Estimated battery usage time remaining 
     BatteryFunction battery_function = 8; // Function of the battery
-    float energy_consumed_wh = 9 [(mavsdk.options.default_value)="NaN"]; // Consumed energy in Watt-hours, NAN if autopilot does not provide energy consumption estimate
 }
 
 /*


### PR DESCRIPTION
Reverts #408.

The `energy_consumed_wh` field does not address the original issue (mavlink/MAVSDK#1748), which asked for current readings. Reverting to avoid confusion.