### PR TITLE
action: add SetHome RPC

### DIFF
--- a/protos/action/action.proto
+++ b/protos/action/action.proto
@@ -165,6 +165,12 @@ service ActionService {
      * Sets the GPS coordinates of the vehicle local origin (0,0,0) position.
      */
      rpc SetGpsGlobalOrigin(SetGpsGlobalOriginRequest) returns(SetGpsGlobalOriginResponse) { option (mavsdk.options.async_type) = SYNC; }
+     /*
+     * Set home.
+     *
+     * Sets the home position.
+     */
+     rpc SetHome(SetHomeRequest) returns(SetHomeResponse) { option (mavsdk.options.async_type) = SYNC; }
 }
 
 message ArmRequest {}
@@ -326,6 +332,16 @@ message SetGpsGlobalOriginResponse {
     ActionResult action_result = 1;
 }
 
+message SetHomeRequest {
+    bool use_current_location = 1; // Use current location
+    double latitude_deg = 2; // Latitude (in degrees)
+    double longitude_deg = 3; // Longitude (in degrees)
+    float absolute_altitude_m = 4; // Altitude AMSL (in meters)
+}
+message SetHomeResponse {
+    ActionResult action_result = 1;
+}
+
 // Result type.
 message ActionResult {
     // Possible results returned for action requests.
@@ -350,3 +366,4 @@ message ActionResult {
     Result result = 1; // Result enum value
     string result_str = 2; // Human-readable English string describing the result
 }
+


### PR DESCRIPTION
Adds `SetHome` RPC and `SetHomeRequest`/`SetHomeResponse` messages to action.proto.

Allows setting the home position via MAV_CMD_DO_SET_HOME.

Closes: https://github.com/mavlink/MAVSDK/issues/2799