### PR TITLE
info: remove GetFlightInformation for 4.0.0

### DIFF
--- a/protos/info/info.proto
+++ b/protos/info/info.proto
@@ -9,8 +9,6 @@ option java_outer_classname = "InfoProto";
 
 // Provide information about the hardware and/or software of a system.
 service InfoService {
-    // Get flight information of the system.
-    rpc GetFlightInformation(GetFlightInformationRequest) returns(GetFlightInformationResponse) { option (mavsdk.options.async_type) = SYNC; }
     // Get the identification of the system.
     rpc GetIdentification(GetIdentificationRequest) returns(GetIdentificationResponse) { option (mavsdk.options.async_type) = SYNC; }
     // Get product information of the system.
@@ -22,12 +20,6 @@ service InfoService {
 
     // Subscribe to 'flight information' updates.
     rpc SubscribeFlightInformation(SubscribeFlightInformationRequest) returns(stream FlightInformationResponse) { option (mavsdk.options.async_type) = ASYNC; }
-}
-
-message GetFlightInformationRequest {}
-message GetFlightInformationResponse {
-    InfoResult info_result = 1;
-    FlightInfo flight_info = 2; // Flight information of the system
 }
 
 message GetIdentificationRequest {}


### PR DESCRIPTION
Closes #389

`GetFlightInformation` conflicts with `SubscribeFlightInformation` during Java code generation, requiring a [workaround in MAVSDK-Java templates](https://github.com/mavlink/MAVSDK-Java/pull/202/files#diff-1af628dc9ec448b27174d543be45c694e23272fea9189d72f90765b4bd491d6a). Removing it as a breaking change for v4.0.0 allows that workaround to be undone.