### PR TITLE
feat(core): add FeedHeartbeatWatchdog RPC

### DIFF
--- a/protos/core/core.proto
+++ b/protos/core/core.proto
@@ -20,6 +20,21 @@ service CoreService {
      * need to be increased to prevent timeouts.
      */
     rpc SetMavlinkTimeout(SetMavlinkTimeoutRequest) returns(SetMavlinkTimeoutResponse) {}
+    /*
+     * Feed the heartbeat watchdog.
+     *
+     * MAVSDK can be configured with a heartbeat watchdog (deadman timer).
+     * While configured, the periodic heartbeats sent by MAVSDK are only sent
+     * as long as this is called at least once per timeout period. If the
+     * watchdog times out, heartbeats stop until it is fed again.
+     *
+     * This allows MAVSDK's heartbeats to reflect the liveness of the client:
+     * if the client hangs or dies, heartbeats stop.
+     *
+     * Has no effect if no watchdog is configured (e.g. with the
+     * --heartbeat-watchdog-timeout option of mavsdk_server).
+     */
+    rpc FeedHeartbeatWatchdog(FeedHeartbeatWatchdogRequest) returns(FeedHeartbeatWatchdogResponse) {}
 }
 
 message SubscribeConnectionStateRequest {}
@@ -31,6 +46,9 @@ message SetMavlinkTimeoutRequest {
     double timeout_s = 1; // Timeout in seconds
 }
 message SetMavlinkTimeoutResponse {}
+
+message FeedHeartbeatWatchdogRequest {}
+message FeedHeartbeatWatchdogResponse {}
 
 // Connection state type.
 message ConnectionState {

--- a/protos/core/core.proto
+++ b/protos/core/core.proto
@@ -32,9 +32,27 @@ service CoreService {
      * if the client hangs or dies, heartbeats stop.
      *
      * Has no effect if no watchdog is configured (e.g. with the
-     * --heartbeat-watchdog-timeout option of mavsdk_server).
+     * --heartbeat-watchdog-timeout option of mavsdk_server, or
+     * SetHeartbeatWatchdogTimeout).
      */
     rpc FeedHeartbeatWatchdog(FeedHeartbeatWatchdogRequest) returns(FeedHeartbeatWatchdogResponse) {}
+    /*
+     * Set the heartbeat watchdog timeout.
+     *
+     * When timeout_s is greater than 0, the periodic heartbeats sent by MAVSDK
+     * are only sent as long as FeedHeartbeatWatchdog is called at least once
+     * per timeout period. If the watchdog times out, heartbeats stop until it
+     * is fed again.
+     *
+     * When timeout_s is 0, the watchdog is disabled and heartbeats follow the
+     * usual policy (always_send_heartbeats or a connected system).
+     *
+     * Values greater than 0 and less than 1 are rejected.
+     *
+     * This is an alternative to configuring the watchdog at mavsdk_server
+     * startup with the --heartbeat-watchdog-timeout option.
+     */
+    rpc SetHeartbeatWatchdogTimeout(SetHeartbeatWatchdogTimeoutRequest) returns(SetHeartbeatWatchdogTimeoutResponse) {}
 }
 
 message SubscribeConnectionStateRequest {}
@@ -49,6 +67,11 @@ message SetMavlinkTimeoutResponse {}
 
 message FeedHeartbeatWatchdogRequest {}
 message FeedHeartbeatWatchdogResponse {}
+
+message SetHeartbeatWatchdogTimeoutRequest {
+    double timeout_s = 1; // Timeout in seconds. 0 disables the watchdog. Minimum 1 when enabled.
+}
+message SetHeartbeatWatchdogTimeoutResponse {}
 
 // Connection state type.
 message ConnectionState {


### PR DESCRIPTION
Adds a gRPC API for external control of MAVSDK heartbeat emission.

When enabled, this disables MAVSDK's internally generated HEARTBEAT sending and instead drives emission from the client via a runtime-configurable deadman timeout. The client refreshes within the timeout to keep heartbeats flowing; if it crashes, disconnects, or stops servicing the path, MAVSDK stops sending, so PX4 sees the GCS/companion component go offline and triggers the configured lost-link failsafe (e.g. RTL). MAVSDK continues to own heartbeat content (sysid, compid, mav_type, etc.); the client only controls whether emission continues. Default behavior is unchanged.

This is the proto/API definition only. The core implementation will follow in a separate PR against mavlink/MAVSDK.

Refs mavlink/MAVSDK#2895

Contributed by Tyler Payne on behalf of Censys Technologies, Inc.