### PR TITLE
camera_server: Add SetPosition, SetAttitude, SetZoomFactor, SetFieldOfView

### DIFF
--- a/protos/camera_server/camera_server.proto
+++ b/protos/camera_server/camera_server.proto
@@ -125,6 +125,12 @@ service CameraServerService {
 
     // Respond to an incoming tracking off command.
     rpc RespondTrackingOffCommand(RespondTrackingOffCommandRequest) returns(RespondTrackingOffCommandResponse) { option (mavsdk.options.async_type) = SYNC; }
+
+    // Set the camera's GPS position.
+    rpc SetPosition(SetPositionRequest) returns(SetPositionResponse) { option (mavsdk.options.async_type) = SYNC; }
+
+    // Set the camera's attitude quaternion.
+    rpc SetAttitudeQuaternion(SetAttitudeQuaternionRequest) returns(SetAttitudeQuaternionResponse) { option (mavsdk.options.async_type) = SYNC; }
 }
 
 
@@ -518,6 +524,20 @@ message RespondTrackingOffCommandRequest {
 }
 message RespondTrackingOffCommandResponse {
     CameraServerResult camera_server_result = 1; // The result of sending the response.
+}
+
+message SetPositionRequest {
+    Position position = 1; // The camera's current GPS position
+}
+message SetPositionResponse {
+    CameraServerResult camera_server_result = 1;
+}
+
+message SetAttitudeQuaternionRequest {
+    Quaternion attitude_quaternion = 1; // The camera's current attitude
+}
+message SetAttitudeQuaternionResponse {
+    CameraServerResult camera_server_result = 1;
 }
 
 // Point description type

--- a/protos/camera_server/camera_server.proto
+++ b/protos/camera_server/camera_server.proto
@@ -131,6 +131,12 @@ service CameraServerService {
 
     // Set the camera's attitude quaternion.
     rpc SetAttitudeQuaternion(SetAttitudeQuaternionRequest) returns(SetAttitudeQuaternionResponse) { option (mavsdk.options.async_type) = SYNC; }
+
+    // Set the camera's zoom factor for CAMERA_FOV_STATUS reporting.
+    rpc SetZoomFactor(SetZoomFactorRequest) returns(SetZoomFactorResponse) { option (mavsdk.options.async_type) = SYNC; }
+
+    // Set the field of view explicitly, for cameras that do not report a zoom factor.
+    rpc SetFieldOfView(SetFieldOfViewRequest) returns(SetFieldOfViewResponse) { option (mavsdk.options.async_type) = SYNC; }
 }
 
 
@@ -537,6 +543,21 @@ message SetAttitudeQuaternionRequest {
     Quaternion attitude_quaternion = 1; // The camera's current attitude
 }
 message SetAttitudeQuaternionResponse {
+    CameraServerResult camera_server_result = 1;
+}
+
+message SetZoomFactorRequest {
+    float zoom_factor = 1; // The camera's current zoom factor, starting at 1x.
+}
+message SetZoomFactorResponse {
+    CameraServerResult camera_server_result = 1;
+}
+
+message SetFieldOfViewRequest {
+    float horizontal_fov_deg = 1; // The camera's current horizontal field of view in degrees
+    float vertical_fov_deg = 2; // The camera's current vertical field of view in degrees
+}
+message SetFieldOfViewResponse {
     CameraServerResult camera_server_result = 1;
 }
 


### PR DESCRIPTION
Adds support for setting camera_server position, attitude, zoom factor and field of view — needed to support `CAMERA_FOV_STATUS` responses.

New RPCs added to `CameraServerService`:
- `SetPosition` — camera GPS position
- `SetAttitudeQuaternion` — camera attitude
- `SetZoomFactor` — zoom factor for FOV calculation
- `SetFieldOfView` — direct H/V FOV in degrees (fallback for cameras without zoom factor)

Companion to MAVSDK PR that adds the C++ implementation (CAMERA_FOV_STATUS request handling, needed for QGC tap-to-point-gimbal: https://github.com/mavlink/qgroundcontrol/pull/13612).

Co-authored-by: jnomikos <john.nomikos55@gmail.com>