### PR TITLE
camera: Add focus_in_step and focus_out_step

### DIFF
--- a/protos/camera/camera.proto
+++ b/protos/camera/camera.proto
@@ -161,6 +161,14 @@ service CameraService {
      */
     rpc TrackStop(TrackStopRequest) returns(TrackStopResponse) {}
     /*
+     * Step focus in.
+     */
+    rpc FocusInStep(FocusInStepRequest) returns(FocusInStepResponse) {}
+    /*
+     * Step focus out.
+     */
+    rpc FocusOutStep(FocusOutStepRequest) returns(FocusOutStepResponse) {}
+    /*
      * Start focusing in.
      */
     rpc FocusInStart(FocusInStartRequest) returns(FocusInStartResponse) {}
@@ -531,6 +539,20 @@ message TrackStopRequest {
     int32 component_id = 1; // Component ID
 }
 message TrackStopResponse {
+    CameraResult camera_result = 1;
+}
+
+message FocusInStepRequest {
+    int32 component_id = 1; // Component ID
+}
+message FocusInStepResponse {
+    CameraResult camera_result = 1;
+}
+
+message FocusOutStepRequest {
+    int32 component_id = 1; // Component ID
+}
+message FocusOutStepResponse {
     CameraResult camera_result = 1;
 }
 


### PR DESCRIPTION
Related Proto PR: https://github.com/mavlink/MAVSDK-Proto/pull/423
MAVSDK PR: https://github.com/mavlink/MAVSDK/pull/3040

In the Proto PR, I had added `SubscribeFocusInStep` and `SubscribeFocusOutStep` for camera_server. When I started adding system tests, I realized I didn't add any way to step focus in or step focus out on the camera plugin.